### PR TITLE
Fix load mpa

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,10 +1,8 @@
 # these values are used in the local docker env. You can use "localhost" hostname if you run the application without docker 
 POSTGRES_HOSTNAME=postgres_bloom
-POSTGRES_HOSTNAME_OUTSIDE_WHEN_DOCKER=localhost # when using docker, the hostname is mapped to the outside world
 POSTGRES_USER=bloom_user
 POSTGRES_PASSWORD=bloom
 POSTGRES_DB=bloom_db
 POSTGRES_PORT=5432
-POSTGRES_PORT_OUTSIDE_WHEN_DOCKER=5480 # when using docker, the port is mapped to the outside world != 5432
 SPIRE_TOKEN=
 SLACK_URL=

--- a/bloom/config.py
+++ b/bloom/config.py
@@ -5,10 +5,8 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     postgres_user = os.environ.get("POSTGRES_USER")
     postgres_password = os.environ.get("POSTGRES_PASSWORD")
-    # postgres_hostname = os.environ.get("POSTGRES_HOSTNAME")
-    postgres_hostname = os.environ.get("POSTGRES_HOSTNAME_OUTSIDE_WHEN_DOCKER") # when using docker
-    # postgres_port = os.environ.get("POSTGRES_PORT")
-    postgres_port = os.environ.get("POSTGRES_PORT_OUTSIDE_WHEN_DOCKER") # when using docker
+    postgres_hostname = os.environ.get("POSTGRES_HOSTNAME")
+    postgres_port = os.environ.get("POSTGRES_PORT")
     postgres_db = os.environ.get("POSTGRES_DB")
     
     print("db_url: ", "postgresql://"+postgres_user+":"+postgres_password+"@"+postgres_hostname+":"+postgres_port+"/"+postgres_db)

--- a/bloom/infra/database/sql_model.py
+++ b/bloom/infra/database/sql_model.py
@@ -112,13 +112,18 @@ IUCN_CATEGORIES = {
 
 
 class MPA(Base):
-    __tablename__ = "mpa"
+    __tablename__ = "mpa_fr_with_mn"
     geometry = Column("geometry", Geometry("POLYGON"))
-    gov_type = Column("GOV_TYPE", Text)
+    #gov_type = Column("GOV_TYPE", Text)
     iucn_category = Column("IUCN_CAT", Text)
-    name = Column("NAME", Text)
+    name = Column("name", Text, nullable=False)
     type = Column("DESIG_TYPE", Text)
-    index = Column("index", BigInteger, primary_key=True, index=True)
+    index = Column("index", Integer, primary_key=True)
+    wdpaid = Column("WDPAID", Float)
+    eng = Column("DESIG_ENG", Text)
+    parent_iso = Column("PARENT_ISO", Text)
+    iso3 = Column("ISO3", Text)
+    benificiaries = Column("Benificiaries", Text)
 
     def __repr__(self) -> str:
         return (


### PR DESCRIPTION
Avoid error "Wrong schema" when using load mpa on the application. 
It fixes function get_closest_marine_protected_areas() that use the sql_model MPA.
Also, I remove duplicates variables for POSTGRES_HOSTNAME / POSTGRES_PORT. Differences between using Docker or not should be in values of these variables not by duplicating variables.