### PR TITLE
Docker various fixes

### DIFF
--- a/alembic/init_script/load_amp_data.py
+++ b/alembic/init_script/load_amp_data.py
@@ -34,7 +34,7 @@ db_url = (
 engine = create_engine(db_url, echo=False)
 
 df = pd.read_csv(
-    Path.joinpath(Path.cwd(), "data/zones_subset_02022024.csv"),
+    Path(os.path.dirname(__file__)).joinpath("../../data/zones_subset_02022024.csv"),
     sep=",",
 )
 

--- a/alembic/init_script/load_positions_data.py
+++ b/alembic/init_script/load_positions_data.py
@@ -31,7 +31,7 @@ db_url = (
 engine = create_engine(db_url)
 
 df = pd.read_csv(
-    Path.joinpath(Path.cwd(), "data/spire_positions_subset_02022024.csv"),
+    Path(os.path.dirname(__file__)).joinpath("../../data/spire_positions_subset_02022024.csv"),
     sep=","
 )
 

--- a/alembic/init_script/load_vessels_data.py
+++ b/alembic/init_script/load_vessels_data.py
@@ -29,7 +29,7 @@ db_url = (
 )
 engine = create_engine(db_url)
 df = pd.read_csv(
-    Path.joinpath(Path.cwd(), "data/chalutiers_pelagiques.csv"),
+    Path(os.path.dirname(__file__)).joinpath("../../data/chalutiers_pelagiques.csv"),
     sep=";",
     dtype={"loa": float, "IMO": str},
 )

--- a/docker-env/Dockerfile
+++ b/docker-env/Dockerfile
@@ -9,6 +9,7 @@ WORKDIR /source_code
 COPY bloom/ ./bloom/
 COPY data/ ./data/
 COPY app.py .
+COPY container.py .
 COPY docker-env/rsyslog.conf /etc/rsyslog.conf
 
 # Install requirements package for python with poetry

--- a/docker-env/Dockerfile
+++ b/docker-env/Dockerfile
@@ -55,8 +55,8 @@ RUN crontab /etc/cron.d/cron_scrapper
 COPY docker-env/entrypoint.sh /entrypoint.sh
 RUN ["chmod", "+x", "/entrypoint.sh"]
 
-#ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]
 # https://manpages.ubuntu.com/manpages/trusty/man8/cron.8.html
 # -f | Stay in foreground mode, don't daemonize.
 # -L loglevel | Tell  cron  what to log about jobs (errors are logged regardless of this value) as the sum of the following values:
-#CMD ["cron","-f", "-L", "2"]
+CMD ["cron","-f", "-L", "2"]

--- a/docker-env/Dockerfile
+++ b/docker-env/Dockerfile
@@ -39,7 +39,11 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -y
     && rm -rf /etc/cron.*/*
 
 # Create cron task inside container
-RUN echo '*/15 * * * *	root /venv/bin/python3 /source_code/app.py 2>&1 | /usr/bin/logger -t bloom'  >> ./cron_scrapper
+# Due to the fact that cron process doesn't access to declared ENV vars and doesn't load user profiles
+# The entrypoint.sh script stores ENV vars at runtime in the ~/.env file as key=value pairs
+# Then the cron line include some command to load these ENV vars from file before launching app.py
+# This mecanism allows to give access to the same ENV vars for app.py launch in terminal and launch via cron
+RUN echo "*/15 * * * *	root export \$(cat ~/.env | grep -v '#' | xargs);/venv/bin/python3 /source_code/app.py 2>&1 | /usr/bin/logger -t bloom"  >> ./cron_scrapper
 RUN chmod 744 ./cron_scrapper
 
 # Move cron tab into the right directory

--- a/docker-env/Dockerfile
+++ b/docker-env/Dockerfile
@@ -39,7 +39,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y --no-install-recommends install -y
     && rm -rf /etc/cron.*/*
 
 # Create cron task inside container
-RUN echo '*/15 * * * *	/venv/bin/python3 /source_code/app.py 2>&1 | /usr/bin/logger -t bloom'  >> ./cron_scrapper
+RUN echo '*/15 * * * *	root /venv/bin/python3 /source_code/app.py 2>&1 | /usr/bin/logger -t bloom'  >> ./cron_scrapper
 RUN chmod 744 ./cron_scrapper
 
 # Move cron tab into the right directory

--- a/docker-env/Dockerfile
+++ b/docker-env/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bullseye
 
 RUN apt-get update
-RUN apt-get -y install wget
+RUN apt-get -y install wget gcc g++
 RUN apt-get install -y rsyslog
 
 # Define working directory

--- a/docker-env/entrypoint.sh
+++ b/docker-env/entrypoint.sh
@@ -2,6 +2,13 @@
 
 cat /source_code/.env >> /etc/environment
 
+# Store all APP_BLOOM ENV variables to local file accessible to current user to share them with cron task
+# Due to the fact that cron process doesn't access to declared ENV vars and doesn't load user profiles
+# The entrypoint.sh script stores ENV vars at runtime in the ~/.env file as key=value pairs
+# Then the cron line include some command to load these ENV vars from file before launching app.py
+# This mecanism allows to give access to the same ENV vars for app.py launch in terminal and launch via cron
+env | egrep '^(POSTGRES_.*|SPIRE_TOKEN.*)' > ~/.env
+
 /etc/init.d/rsyslog restart
 
 ln -sf /dev/stdout /var/log/syslog


### PR DESCRIPTION
# Fixes:
* add container.py to Dockerfile avoiding  No module named 'container' at runtime error
* add root userin cron_scrapper avoiding user missing error at runtime
* modify the way ENV vars are shared between Docker root terminal and cron process storing env parameters in ~/.env and loading them in cron line
* add packages needed for python version > 3.11 and package compilation
* modify the path of data in alembic/init_script/load_*, using relative path from script instead of CWD that could be different from projet home in Docker and host native installation
* (re) activation of entreypoint/cmd dockerfile to get a docker container running as a production one instead of python shell
* remove the print of db_url values, avoiding password presence in console logs and docker logs

QUESTION: What is the use of POSTGRES_HOSTNAME_OUTSIDE_WHEN_DOCKER and POSTGRES_PORT_OUTSIDE_WHEN_DOCKER exactly ?