### PR TITLE
feat: migration use of docker compose and env by file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,8 +1,17 @@
 # these values are used in the local docker env. You can use "localhost" hostname if you run the application without docker 
-POSTGRES_HOSTNAME=postgres_bloom
-POSTGRES_USER=bloom_user
-POSTGRES_PASSWORD=bloom
-POSTGRES_DB=bloom_db
+# APP_ENV is here to set the runtime environment
+# values: dev|test|prod
+APP_ENV=test
+
+# VERSION
+# is used as bloom:${VERSION}
+VERSION=1.0.0
+
+
+POSTGRES_HOST=postgres_bloom-test	
+POSTGRES_USER=bloom_user-test
+POSTGRES_PASSWORD=bloom-test
+POSTGRES_DB=bloom_test
 POSTGRES_PORT=5432
 SPIRE_TOKEN=
 SLACK_URL=

--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ celerybeat.pid
 
 # Environments
 .env
-.env.test
+.env.*
 .venv
 env/
 venv/

--- a/docker-env/docker-compose.yaml
+++ b/docker-env/docker-compose.yaml
@@ -1,0 +1,81 @@
+version: "3.7"
+
+x-common-infos:
+  # Env variables stored in a .env file
+  environment: &common-env
+    POSTGRES_HOST: ${POSTGRES_HOST:-postgres_bloom}
+    POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    POSTGRES_DB: ${POSTGRES_DB:-bloom_db}
+    POSTGRES_USER: ${POSTGRES_USER:-boom_user}
+    POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bloom}
+services:    
+  db-dev:
+    container_name: postgres_bloom-${APP_ENV}
+    image: ${POSTGIS_IMAGE:-postgis/postgis:14-3.3-alpine}
+    ports:
+      - ${POSTGRES_PORT:-5432}:5432
+    env_file: ../.env.dev
+    environment:
+      <<: *common-env
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready --quiet --dbname=${POSTGRES_DB} --username=${POSTGRES_USER}']
+      interval: 100ms
+      timeout: 14s
+      retries: 140
+      start_period: 0s
+    networks:
+        - bloom_net
+    restart: unless-stopped
+
+  app-dev:
+      container_name: app_bloom-${APP_ENV:-dev}
+      hostname: app_bloom-${APP_ENV:-dev}
+      build:
+        context: ..
+        dockerfile: docker-env/Dockerfile
+        args:
+            CHROME_VERSION: "112.0.5615.165-1"
+            APP_DIR: /source_code
+            FROM_IMAGE: ${FROM_IMAGE:-python:3.10-slim-bullseye}
+            APP_ENV: ${APP_ENV:-dev}
+      image: dataforgood/bloom:${VERSION:-latest}
+      env_file:
+        - ../.env.dev
+
+      command: /bin/bash
+      tty: true
+      stdin_open: true
+      environment:
+        <<: *common-env
+        SPIRE_TOKEN_FILE: /run/secrets/spire_token
+      volumes:
+        - ../data:/source_code/data
+        - ../alembic:/source_code/alembic
+      networks:
+        - bloom_net
+      restart: unless-stopped
+      configs:
+        - source: .env.dev
+          target: /source_code/.env
+  
+  dbadmin-dev:
+    container_name: pgadmin_bloom-${APP_ENV} 
+    image: dpage/pgadmin4
+    environment:
+        <<: *common-env
+        PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL:-pgadmin@pgadmin.com}
+        PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD:-pgadmin}
+    env_file:
+      - ../.env.dev
+
+configs:
+  .env.dev:
+    file: ../.env.dev
+
+secrets:
+  spire_token_dev:
+    file: ../secrets/dev/spire_token  
+
+networks:
+  bloom_net:
+    name: bloom_net


### PR DESCRIPTION
The goal of this PR is : 
* redesign docker environment set up for dev and test at least, production basics eventually 
* create/modify  docker compose file(s)
* Update Makefile and proposing homogeneous and simple targets

For docker compose:
* manage build
* describe directly the environment un docker-compose file
* manage dev/test environment at least
* manage secrets

Don't hesitate to add/correct things