### PR TITLE
[02] fix: Python 3.9 syntax compatibility

### DIFF
--- a/bloom/bloom/domain/alert.py
+++ b/bloom/bloom/domain/alert.py
@@ -2,9 +2,11 @@ from datetime import datetime
 
 from pydantic import BaseModel
 
+from typing import Union
+
 
 class Alert(BaseModel):
-    ship_name: str | None
+    ship_name: Union [ str , None]
     mmsi: int
     last_position_time: datetime
     position: str

--- a/bloom/bloom/domain/vessel.py
+++ b/bloom/bloom/domain/vessel.py
@@ -3,34 +3,36 @@ from datetime import datetime, timezone
 from pydantic import BaseModel, validator
 from shapely import Point
 
+from typing import Union
+
 
 class Vessel(BaseModel):
     vessel_id: int
-    ship_name: str | None
-    IMO: str | None
-    mmsi: int | None
+    ship_name: Union[str, None]
+    IMO: Union[str, None]
+    mmsi: Union[int, None]
 
     def get_mmsi(self) -> int:
         return self.mmsi
 
 
 class VesselPositionMarineTraffic(BaseModel):
-    timestamp: datetime | None
-    ship_name: str | None
-    current_port: str | None
-    IMO: str | None
+    timestamp: Union[datetime, None]
+    ship_name: Union[str, None]
+    current_port: Union[str, None]
+    IMO: Union[str, None]
     vessel_id: int
-    mmsi: str | None
-    last_position_time: datetime | None
-    ship_name: str | None
+    mmsi: Union[str, None]
+    last_position_time: Union[datetime, None]
+    ship_name: Union[str, None]
     IMO: str
-    mmsi: str | None
-    fishing: bool | None
-    at_port: bool | None
-    position: Point | None
-    status: str | None
-    speed: float | None
-    navigation_status: str | None
+    mmsi: Union[str, None]
+    fishing: Union[ bool, None]
+    at_port: Union[ bool, None]
+    position: Union[Point, None]
+    status: Union[str, None]
+    speed: Union[float, None]
+    navigation_status: Union[str, None]
 
     class Config:
         arbitrary_types_allowed = True
@@ -45,7 +47,7 @@ class VesselPositionMarineTraffic(BaseModel):
         )
 
     @validator("last_position_time", pre=True)
-    def format_last_position_time(cls, value: str) -> datetime | None:
+    def format_last_position_time(cls, value: str) -> Union [ datetime, None ]:
         if isinstance(value, str):
             return datetime.strptime(value, "%Y-%m-%d %H:%M UTC").replace(
                 tzinfo=timezone.utc,

--- a/bloom/bloom/infra/http/marine_traffic_scraper.py
+++ b/bloom/bloom/infra/http/marine_traffic_scraper.py
@@ -2,6 +2,8 @@ import os
 import re
 from datetime import datetime, timezone
 
+from typing import Union
+
 from selenium.common import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
@@ -135,7 +137,7 @@ class MarineTrafficVesselScraper:
         return vessels_list
 
     @staticmethod
-    def _extract_speed_from_scrapped_field(speed_field: str) -> float | None:
+    def _extract_speed_from_scrapped_field(speed_field: str) -> Union[ float , None ]:
         speed = re.findall(r"[\d]*[.][\d]*", speed_field)
         if len(speed) > 0:
             return float(speed[0])

--- a/bloom/bloom/infra/repositories/repository_vessel.py
+++ b/bloom/bloom/infra/repositories/repository_vessel.py
@@ -1,7 +1,7 @@
 from contextlib import AbstractContextManager
 from datetime import datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Union
 
 import geopandas as gpd
 import pandas as pd
@@ -219,8 +219,8 @@ class RepositoryVessel:
         self,
         mmsi: str,
         as_trajectory: bool = True,
-    ) -> Point | None: #Point ?
-        def convert_wkb_to_point(x: Any) -> Point | None:
+    ) -> Union[ Point, None ]:
+        def convert_wkb_to_point(x: Any) -> Union[ Point, None ]:
             try:
                 point = wkb.loads(bytes(x.data))
                 return point  # noqa: TRY300


### PR DESCRIPTION
To conforme to Data For Good preconisation to support all LTS python versions (3.8-3.12 today), the modification is to use syntax compliante with 3.9

geopandas has restriction to use python version >=3.9 <3.12 and for 3.9.7 specific version
pyproject.toml is taking account about these constraints