### PR TITLE
Add githubs actions to check compiance with LTS python versions 3.9-3.11

### DIFF
--- a/.github/workflows/version_supports.yaml
+++ b/.github/workflows/version_supports.yaml
@@ -1,0 +1,27 @@
+name: version supports
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+        matrix:
+            python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+    steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+        - name: Set up Python ${{ matrix.python-version }}
+          uses: actions/setup-python@v2
+          with:
+            python-version: ${{ matrix.python-version }}
+        - name: Install dependencies
+          run: |
+            python -m pip install --upgrade pip
+            pip install tox tox-gh-actions
+        - name: Test package with tox
+          run: tox -vv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,11 +3,7 @@ FROM ${IMAGE_PYTHON}
 
 RUN apt-get update &&\
 	apt-get -y install wget &&\
-	apt-get install -y rsyslog &&\
-# prerequisites for python 3.11
-	apt-get install -y gcc g++ &&\
-# prerequisites for python 3.12
-	apt-get install -y 	libgeos-dev
+	apt-get install -y rsyslog
 
 # Define working directory
 ARG PROJECT_DIR=/project

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,10 +2,12 @@ ARG IMAGE_PYTHON=${IMAGE_PYTHON:-python:3.10-slim-bullseye}
 FROM ${IMAGE_PYTHON}
 
 RUN apt-get update &&\
-	apt-get -y install wget gcc &&\
+	apt-get -y install wget &&\
 	apt-get install -y rsyslog &&\
-# added for python 3.11/12 compliance
-	apt-get install -y g++ libgeos-dev
+# prerequisites for python 3.11
+	apt-get install -y gcc g++ &&\
+# prerequisites for python 3.12
+	apt-get install -y 	libgeos-dev
 
 # Define working directory
 ARG PROJECT_DIR=/project


### PR DESCRIPTION
Try to install POETRY for python versions 3.8, 3.9, 3.10, 3.11, 3.12

* 3.12 is failing because of dependency_injection package not compliant with 3.12
* 3.8 is installing with no error but poetry should not permit this kind of installation as geopandas as a python >= 3.9 restriction
* 3.11 is installing with no error but is taking a really long time to install, maybe linked to compilation and add of 2 prerequisite gcc and libgeos-dev