### PR TITLE
fix: github action build docker => docker-env => docker/Dockerfile

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -44,7 +44,7 @@ jobs:
       uses: docker/build-push-action@v4
       with:
         context: .
-        file: ./docker-env/Dockerfile
+        file: ./docker/Dockerfile
         platforms: linux/amd64
         push: true
         tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
J'y ai pensé après mais oublié de remettre à jour le github action de build avec le bon chemin vers le Dockerfile