### PR TITLE
docker: ajout compute_port_geometry_buffer dans procédure load with data

### DIFF
--- a/docker-compose-load-data.yaml
+++ b/docker-compose-load-data.yaml
@@ -19,6 +19,7 @@ services:
         /venv/bin/python3 backend/bloom/tasks/load_dim_zone_amp_from_csv.py &&
         /venv/bin/python3 backend/bloom/tasks/load_dim_port_from_csv.py &&
         /venv/bin/python3 backend/bloom/tasks/load_spire_data_from_csv.py &&
+        /venv/bin/python3 backend/bloom/tasks/compute_port_geometry_buffer.py &&
         /venv/bin/python3 backend/bloom/tasks/clean_positions.py --batch-time 100000 &&
         /venv/bin/python3 backend/bloom/tasks/create_update_excursions_segments.py"
     volumes:


### PR DESCRIPTION
Ajout de la tâche compute_port_geometry_buffer dans la procédure docker-compose-load-data