### PR TITLE
[FEAT] Add dashboard metric endpoints #204

### DIFF
--- a/backend/bloom/domain/api.py
+++ b/backend/bloom/domain/api.py
@@ -27,12 +27,27 @@ def check_cache(request:Request):
     cache= rd.get(request.url.path)
 
 class DatetimeRangeRequest(BaseModel):
-    start_at: datetime = datetime.now()-timedelta(days=7)
+    start_at: datetime = Field(default=datetime.now()-timedelta(days=7))
     end_at: datetime = datetime.now()
 
 class OrderByEnum(str, Enum):
     ascending = "ASC"
     descending = "DESC"
+
+
+class TotalTimeActivityTypeEnum(str, Enum):
+    total_time_at_sea: str = "Total Time at Sea"
+    total_time_in_amp: str = "Total Time in AMP"
+    total_time_in_territorial_waters: str = "Total Time in Territorial Waters"
+    total_time_in_costal_waters: str = "Total Time in Costal Waters"
+    total_time_fishing: str = "Total Time Fishing"
+    total_time_fishing_in_amp: str = "Total Time Fishing in AMP"
+    total_time_fishing_in_territorial_waters: str = "Total Time Fishing in Territorial Waters"
+    total_time_fishing_in_costal_waters: str = "Total Time Fishing in Costal Waters"
+    total_time_fishing_in_extincting_amp: str = "Total Time in Extincting AMP"
+
+class TotalTimeActivityTypeRequest(BaseModel):
+    type: TotalTimeActivityTypeEnum
 
 class OrderByRequest(BaseModel):
     order: OrderByEnum = OrderByEnum.ascending
@@ -46,7 +61,7 @@ class PaginatedRequest(BaseModel):
 class PageParams(BaseModel):
     """ Request query params for paginated API. """
     offset: conint(ge=0) = 0
-    limit: conint(ge=1, le=1000) = 100
+    limit: conint(ge=1, le=100000) = 100
 
 T = TypeVar("T")
 

--- a/backend/bloom/domain/api.py
+++ b/backend/bloom/domain/api.py
@@ -4,6 +4,7 @@ from typing import Generic,TypeVar, List
 from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
 from enum import Enum
+import redis
 from pydantic.generics import GenericModel
 from fastapi.security import APIKeyHeader
 from bloom.config import settings
@@ -12,6 +13,8 @@ from bloom.config import settings
 ## https://jayhawk24.hashnode.dev/how-to-implement-pagination-in-fastapi-feat-sqlalchemy
 X_API_KEY_HEADER=APIKeyHeader(name="x-key")
 
+rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
 class CachedRequest(BaseModel):
     nocache:bool=False
 
@@ -19,6 +22,9 @@ def check_apikey(key:str):
     if key != settings.api_key :
         raise HTTPException(status_code=401, detail="Unauthorized")
     return True
+
+def check_cache(request:Request):
+    cache= rd.get(request.url.path)
 
 class DatetimeRangeRequest(BaseModel):
     start_at: datetime = datetime.now()-timedelta(days=7)

--- a/backend/bloom/domain/api.py
+++ b/backend/bloom/domain/api.py
@@ -12,6 +12,9 @@ from bloom.config import settings
 ## https://jayhawk24.hashnode.dev/how-to-implement-pagination-in-fastapi-feat-sqlalchemy
 X_API_KEY_HEADER=APIKeyHeader(name="x-key")
 
+class CachedRequest(BaseModel):
+    nocache:bool=False
+
 def check_apikey(key:str):
     if key != settings.api_key :
         raise HTTPException(status_code=401, detail="Unauthorized")

--- a/backend/bloom/domain/api.py
+++ b/backend/bloom/domain/api.py
@@ -1,4 +1,4 @@
-from fastapi import Request
+from fastapi import Request, HTTPException
 from pydantic import BaseModel, ConfigDict, Field,conint
 from typing import Generic,TypeVar, List
 from typing_extensions import Annotated, Literal, Optional
@@ -6,10 +6,16 @@ from datetime import datetime, timedelta
 from enum import Enum
 from pydantic.generics import GenericModel
 from fastapi.security import APIKeyHeader
+from bloom.config import settings
 
 ## Reference for pagination design
 ## https://jayhawk24.hashnode.dev/how-to-implement-pagination-in-fastapi-feat-sqlalchemy
 X_API_KEY_HEADER=APIKeyHeader(name="x-key")
+
+def check_apikey(key:str):
+    if key != settings.api_key :
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    return True
 
 class DatetimeRangeRequest(BaseModel):
     start_at: datetime = datetime.now()-timedelta(days=7)

--- a/backend/bloom/domain/api.py
+++ b/backend/bloom/domain/api.py
@@ -1,0 +1,59 @@
+from fastapi import Request
+from pydantic import BaseModel, ConfigDict, Field,conint
+from typing import Generic,TypeVar, List
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+from enum import Enum
+from pydantic.generics import GenericModel
+from fastapi.security import APIKeyHeader
+
+## Reference for pagination design
+## https://jayhawk24.hashnode.dev/how-to-implement-pagination-in-fastapi-feat-sqlalchemy
+X_API_KEY_HEADER=APIKeyHeader(name="x-key")
+
+class DatetimeRangeRequest(BaseModel):
+    start_at: datetime = datetime.now()-timedelta(days=7)
+    end_at: datetime = datetime.now()
+
+class OrderByEnum(str, Enum):
+    ascending = "ASC"
+    descending = "DESC"
+
+class OrderByRequest(BaseModel):
+    order: OrderByEnum = OrderByEnum.ascending
+
+class PaginatedRequest(BaseModel):
+    offset: int|None = 0
+    limit: int|None = 100
+    order_by: OrderByRequest = OrderByEnum.ascending
+
+
+class PageParams(BaseModel):
+    """ Request query params for paginated API. """
+    offset: conint(ge=0) = 0
+    limit: conint(ge=1, le=1000) = 100
+
+T = TypeVar("T")
+
+class PagedResponseSchema(GenericModel,Generic[T]):
+    total: int
+    limit: int
+    offset: int
+    next: str|None
+    previous: str|None
+    results: List[T]
+
+def paginate(request: Request, page_params: PageParams, query, ResponseSchema: BaseModel) -> PagedResponseSchema[T]:
+    """Paginate the query."""
+
+    print(f"{request.url.scheme}://{request.client}/{request.url.path}")
+    paginated_query = query.offset((page_params.offset) * page_params.limit).limit(page_params.limit).all()
+
+    return PagedResponseSchema(
+        total=query.count(),
+        offset=page_params.offset,
+        limit=page_params.limit,
+        next="",
+        previous="",
+        results=[ResponseSchema.from_orm(item) for item in paginated_query],
+    )

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -4,7 +4,7 @@ from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
 from enum import Enum
 
-class ResponseMetricsVesselInActiviySchema(BaseModel):
+class ResponseMetricsVesselInActivitySchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     id: int
     mmsi: int

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -1,8 +1,11 @@
 from pydantic import BaseModel, ConfigDict
+from typing import Generic,TypeVar, List
 from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
+from enum import Enum
 
 class ResponseMetricsVesselInActiviySchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
     id: int
     mmsi: int
     ship_name: str
@@ -39,8 +42,3 @@ class ResponseMetricsZoneVisitingTimeByVesselSchema(BaseModel):
     vessel_type: Optional[str] = None
     vessel_length_class: Optional[str] = None
     zone_visiting_time_by_vessel: timedelta
-
-    
-class TemporalRequest(BaseModel):
-    start_at: datetime
-    end_at: datetime = datetime.now()

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+
+class ResponseMetricsVesselInActiviySchema(BaseModel):
+    id: int
+    mmsi: int
+    ship_name: str
+    width: Optional[float] = None
+    length: Optional[float] = None
+    country_iso3: Optional[str] = None
+    type: Optional[str] = None
+    imo: Optional[int] = None
+    cfr: Optional[str] = None
+    external_marking: Optional[str] = None
+    ircs: Optional[str] = None
+    home_port_id: Optional[int] = None
+    details: Optional[str] = None
+    tracking_activated: Optional[bool]
+    tracking_status: Optional[str]
+    length_class: Optional[str]
+    check: Optional[str]
+    total_time_at_sea: timedelta
+
+class ResponseMetricsZoneVisitedSchema(BaseModel):
+    id : int
+    category: str
+    sub_category: Optional[str] = None
+    name: str
+    visiting_duration: timedelta
+
+class ResponseMetricsZoneVisitingTimeByVesselSchema(BaseModel):
+    zone_id : int
+    zone_category: str
+    zone_sub_category: Optional[str] = None
+    zone_name: str
+    vessel_id : int
+    vessel_name: str
+    vessel_type: Optional[str] = None
+    vessel_length_class: Optional[str] = None
+    zone_visiting_time_by_vessel: timedelta
+
+    
+class TemporalRequest(BaseModel):
+    start_at: datetime
+    end_at: datetime = datetime.now()

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -8,7 +8,7 @@ from bloom.domain.vessel import Vessel
 class ResponseMetricsVesselInActivitySchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     vessel_id: Optional[int]
-    """        vessel_mmsi: int
+    vessel_mmsi: int
     vessel_ship_name: str
     vessel_width: Optional[float] = None
     vessel_length: Optional[float] = None
@@ -23,7 +23,7 @@ class ResponseMetricsVesselInActivitySchema(BaseModel):
     vessel_tracking_activated: Optional[bool]
     vessel_tracking_status: Optional[str]
     vessel_length_class: Optional[str]
-    vessel_check: Optional[str]"""
+    vessel_check: Optional[str]
     total_time_at_sea: Optional[timedelta]
 
 class ResponseMetricsZoneVisitedSchema(BaseModel):
@@ -43,3 +43,7 @@ class ResponseMetricsZoneVisitingTimeByVesselSchema(BaseModel):
     vessel_type: Optional[str] = None
     vessel_length_class: Optional[str] = None
     zone_visiting_time_by_vessel: timedelta
+
+class ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema(BaseModel):
+    vessel_id : int
+    total_activity_time: timedelta

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -3,33 +3,34 @@ from typing import Generic,TypeVar, List
 from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
 from enum import Enum
+from bloom.domain.vessel import Vessel
 
 class ResponseMetricsVesselInActivitySchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
-    id: int
-    mmsi: int
-    ship_name: str
-    width: Optional[float] = None
-    length: Optional[float] = None
-    country_iso3: Optional[str] = None
-    type: Optional[str] = None
-    imo: Optional[int] = None
-    cfr: Optional[str] = None
-    external_marking: Optional[str] = None
-    ircs: Optional[str] = None
-    home_port_id: Optional[int] = None
-    details: Optional[str] = None
-    tracking_activated: Optional[bool]
-    tracking_status: Optional[str]
-    length_class: Optional[str]
-    check: Optional[str]
-    total_time_at_sea: timedelta
+    vessel_id: Optional[int]
+    """        vessel_mmsi: int
+    vessel_ship_name: str
+    vessel_width: Optional[float] = None
+    vessel_length: Optional[float] = None
+    vessel_country_iso3: Optional[str] = None
+    vessel_type: Optional[str] = None
+    vessel_imo: Optional[int] = None
+    vessel_cfr: Optional[str] = None
+    vessel_external_marking: Optional[str] = None
+    vessel_ircs: Optional[str] = None
+    vessel_home_port_id: Optional[int] = None
+    vessel_details: Optional[str] = None
+    vessel_tracking_activated: Optional[bool]
+    vessel_tracking_status: Optional[str]
+    vessel_length_class: Optional[str]
+    vessel_check: Optional[str]"""
+    total_time_at_sea: Optional[timedelta]
 
 class ResponseMetricsZoneVisitedSchema(BaseModel):
-    id : int
-    category: str
-    sub_category: Optional[str] = None
-    name: str
+    zone_id : int
+    zone_category: Optional[str]
+    zone_sub_category: Optional[str] = None
+    zone_name: str
     visiting_duration: timedelta
 
 class ResponseMetricsZoneVisitingTimeByVesselSchema(BaseModel):

--- a/backend/bloom/routers/metrics.py
+++ b/backend/bloom/routers/metrics.py
@@ -25,7 +25,7 @@ redis_client = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
 @router.get("/metrics/vessels-in-activity",
             response_model=list[ResponseMetricsVesselInActiviySchema],
-            tags=['metrics'])
+            tags=['Metrics'])
 def read_metrics_vessels_in_activity_total(request: Request,
                                            datetime_range: DatetimeRangeRequest = Depends(),
                                            #pagination: PageParams = Depends(),
@@ -73,7 +73,7 @@ def read_metrics_vessels_in_activity_total(request: Request,
 
 @router.get("/metrics/zone-visited",
             response_model=list[ResponseMetricsZoneVisitedSchema],
-            tags=['metrics'] )
+            tags=['Metrics'] )
 def read_metrics_vessels_in_activity_total(datetime_range: DatetimeRangeRequest = Depends(),
                                            pagination: PaginatedRequest = Depends(),
                                            auth: str = Depends(X_API_KEY_HEADER),):
@@ -101,7 +101,7 @@ def read_metrics_vessels_in_activity_total(datetime_range: DatetimeRangeRequest 
 
 @router.get("/metrics/zones/{zone_id}/visiting-time-by-vessel",
             response_model=list[ResponseMetricsZoneVisitingTimeByVesselSchema],
-            tags=['metrics'])
+            tags=['Metrics'])
 def read_metrics_zone_visiting_time_by_vessel(
                     datetime_range: Annotated[DatetimeRangeRequest,Body()],
                     zone_id: int,
@@ -133,7 +133,7 @@ def read_metrics_zone_visiting_time_by_vessel(
 
 
 
-@router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['metrics'])
+@router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['Metrics'])
 def read_metrics_vessels_visits_by_visit_type(
         vessel_id: int,
         visit_type: str,

--- a/backend/bloom/routers/metrics.py
+++ b/backend/bloom/routers/metrics.py
@@ -1,0 +1,28 @@
+from fastapi import APIRouter, Depends, Query
+from redis import Redis
+from bloom.config import settings
+from bloom.container import UseCases
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated, Literal
+from datetime import datetime
+
+router = APIRouter()
+redis_client = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
+@router.get("/metrics/vessels-in-activity/total", tags=['metrics'])
+def read_metrics_vessels_in_activity_total(start_at: datetime, end_at: datetime = None):
+    pass
+
+@router.get("/metrics/zone-visited/total", tags=['metrics'])
+def read_metrics_vessels_in_activity_total(start_at: datetime, end_at: datetime = None):
+    pass
+
+@router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['metrics'])
+def read_metrics_vessels_visits_by_visit_type(
+        vessel_id: int,
+        visit_type: str,
+        start_at: datetime,
+        end_at: datetime = None,
+        limit: int = 10,
+        orderBy: str = 'DESC'):
+    pass

--- a/backend/bloom/routers/metrics.py
+++ b/backend/bloom/routers/metrics.py
@@ -7,34 +7,19 @@ from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
 from sqlalchemy import select, func, and_, or_
 from bloom.infra.database import sql_model
-from bloom.domain.segment import Segment
 from bloom.infra.repositories.repository_segment import SegmentRepository
 import json
 from pydantic import BaseModel, ConfigDict
+from bloom.domain.metrics import ResponseMetricsVesselInActiviySchema,\
+                                 ResponseMetricsZoneVisitedSchema,\
+                                 ResponseMetricsZoneVisitingTimeByVesselSchema,\
+                                 DatetimeRangeRequest
 
 router = APIRouter()
 redis_client = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
 
-class ResponseMetricsVesselInActiviySchema(BaseModel):
-    id: int
-    mmsi: int
-    ship_name: str
-    width: Optional[float] = None
-    length: Optional[float] = None
-    country_iso3: Optional[str] = None
-    type: Optional[str] = None
-    imo: Optional[int] = None
-    cfr: Optional[str] = None
-    external_marking: Optional[str] = None
-    ircs: Optional[str] = None
-    home_port_id: Optional[int] = None
-    details: Optional[str] = None
-    tracking_activated: Optional[bool]
-    tracking_status: Optional[str]
-    length_class: Optional[str]
-    check: Optional[str]
-    total_time_at_sea: timedelta
+
 
 @router.get("/metrics/vessels-in-activity",
             response_model=list[ResponseMetricsVesselInActiviySchema],
@@ -84,12 +69,67 @@ def read_metrics_vessels_in_activity_total(start_at: datetime,
         return  session.execute(stmt).all()
 
 @router.get("/metrics/zone-visited",
+            response_model=list[ResponseMetricsZoneVisitedSchema],
             tags=['metrics'] )
 def read_metrics_vessels_in_activity_total(start_at: datetime,
-                                           end_at: datetime = None,
+                                           end_at: datetime = datetime.now(),
                                            limit: int = None,
                                            order_by: str = 'DESC'):
-    pass
+    use_cases = UseCases()
+    db = use_cases.db()
+    with db.session() as session:
+        stmt=select(
+            sql_model.Zone.id.label("zone_id"),
+            sql_model.Zone.category.label("zone_category"),
+            sql_model.Zone.sub_category.label("zone_sub_category"),
+            sql_model.Zone.name.label("zone_name"),
+            func.sum(sql_model.Segment.segment_duration).label("visiting_duration")
+            )\
+            .where(
+                or_(
+                    sql_model.Segment.timestamp_start.between(start_at,end_at),
+                    sql_model.Segment.timestamp_end.between(start_at,end_at),)
+            )\
+            .group_by(sql_model.Zone.id)
+        stmt = stmt.limit(limit) if limit != None else stmt
+        stmt =  stmt.order_by("visiting_duration")\
+                if  order_by.upper() == 'ASC' \
+                else stmt.order_by("visiting_duration") 
+        return  session.execute(stmt).all()
+
+@router.get("/metrics/zones/{zone_id}/visiting-time-by-vessel",
+            response_model=list[ResponseMetricsZoneVisitingTimeByVesselSchema],
+            tags=['metrics'])
+def read_metrics_zone_visiting_time_by_vessel(
+                    zone_id: int,
+                    start_at: datetime,
+                    end_at: datetime = datetime.now(),
+                    limit: int = None,
+                    order_by: str = 'DESC'):
+    use_cases = UseCases()
+    db = use_cases.db()
+    with db.session() as session:
+        stmt=select(
+            sql_model.Zone.id.label("zone_id"),
+            sql_model.Zone.category.label("zone_category"),
+            sql_model.Zone.sub_category.label("zone_sub_category"),
+            sql_model.Zone.name.label("zone_name"),
+            sql_model.Vessel.id.label("vessel_id"),
+            sql_model.Vessel.ship_name.label("vessel_name"),
+            sql_model.Vessel.type.label("vessel_type"),
+            sql_model.Vessel.length_class.label("vessel_length_class"),
+            func.sum(sql_model.Segment.segment_duration).label("zone_visiting_time_by_vessel")
+        )\
+        .select_from(sql_model.Zone)\
+        .join(sql_model.RelSegmentZone, sql_model.RelSegmentZone.zone_id == sql_model.Zone.id)\
+        .join(sql_model.Segment, sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
+        .join(sql_model.Excursion, sql_model.Excursion.id == sql_model.Segment.excursion_id)\
+        .join(sql_model.Vessel, sql_model.Excursion.vessel_id == sql_model.Vessel.id)\
+        .where(sql_model.Zone.id == zone_id)\
+        .group_by(sql_model.Zone.id,sql_model.Vessel.id)
+        return  session.execute(stmt).all()
+
+
 
 @router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['metrics'])
 def read_metrics_vessels_visits_by_visit_type(

--- a/backend/bloom/routers/metrics.py
+++ b/backend/bloom/routers/metrics.py
@@ -3,18 +3,92 @@ from redis import Redis
 from bloom.config import settings
 from bloom.container import UseCases
 from pydantic import BaseModel, Field
-from typing_extensions import Annotated, Literal
-from datetime import datetime
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+from sqlalchemy import select, func, and_, or_
+from bloom.infra.database import sql_model
+from bloom.domain.segment import Segment
+from bloom.infra.repositories.repository_segment import SegmentRepository
+import json
+from pydantic import BaseModel, ConfigDict
 
 router = APIRouter()
 redis_client = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
-@router.get("/metrics/vessels-in-activity/total", tags=['metrics'])
-def read_metrics_vessels_in_activity_total(start_at: datetime, end_at: datetime = None):
-    pass
 
-@router.get("/metrics/zone-visited/total", tags=['metrics'])
-def read_metrics_vessels_in_activity_total(start_at: datetime, end_at: datetime = None):
+class ResponseMetricsVesselInActiviySchema(BaseModel):
+    id: int
+    mmsi: int
+    ship_name: str
+    width: Optional[float] = None
+    length: Optional[float] = None
+    country_iso3: Optional[str] = None
+    type: Optional[str] = None
+    imo: Optional[int] = None
+    cfr: Optional[str] = None
+    external_marking: Optional[str] = None
+    ircs: Optional[str] = None
+    home_port_id: Optional[int] = None
+    details: Optional[str] = None
+    tracking_activated: Optional[bool]
+    tracking_status: Optional[str]
+    length_class: Optional[str]
+    check: Optional[str]
+    total_time_at_sea: timedelta
+
+@router.get("/metrics/vessels-in-activity",
+            response_model=list[ResponseMetricsVesselInActiviySchema],
+            tags=['metrics'])
+def read_metrics_vessels_in_activity_total(start_at: datetime,
+                                           end_at: datetime = datetime.now(),
+                                           limit: int = None,
+                                           order_by: str = 'DESC'
+                                           ):
+    use_cases = UseCases()
+    db = use_cases.db()
+    with db.session() as session:
+        stmt=select(sql_model.Vessel.id,
+                    sql_model.Vessel.mmsi,
+                    sql_model.Vessel.ship_name,
+                    sql_model.Vessel.width,
+                    sql_model.Vessel.length,
+                    sql_model.Vessel.country_iso3,
+                    sql_model.Vessel.type,
+                    sql_model.Vessel.imo,
+                    sql_model.Vessel.cfr,
+                    sql_model.Vessel.external_marking,
+                    sql_model.Vessel.ircs,
+                    sql_model.Vessel.home_port_id,
+                    sql_model.Vessel.details,
+                    sql_model.Vessel.tracking_activated,
+                    sql_model.Vessel.tracking_status,
+                    sql_model.Vessel.length_class,
+                    sql_model.Vessel.check,
+                    func.sum(sql_model.Excursion.total_time_at_sea).label("total_time_at_sea")
+                    )\
+            .select_from(sql_model.Segment)\
+            .join(sql_model.Excursion, sql_model.Segment.excursion_id == sql_model.Excursion.id)\
+            .join(sql_model.Vessel, sql_model.Excursion.vessel_id == sql_model.Vessel.id)\
+            .where(
+                or_(
+                    sql_model.Excursion.arrival_at.between(start_at,end_at),
+                    and_(sql_model.Excursion.departure_at <= end_at,
+                         sql_model.Excursion.arrival_at == None))
+            )\
+            .group_by(sql_model.Vessel.id,sql_model.Excursion.total_time_at_sea)
+        stmt = stmt.limit(limit) if limit != None else stmt
+            
+        stmt =  stmt.order_by(sql_model.Excursion.total_time_at_sea.asc())\
+                if  order_by.upper() == 'ASC' \
+                else stmt.order_by(sql_model.Excursion.total_time_at_sea.desc())        
+        return  session.execute(stmt).all()
+
+@router.get("/metrics/zone-visited",
+            tags=['metrics'] )
+def read_metrics_vessels_in_activity_total(start_at: datetime,
+                                           end_at: datetime = None,
+                                           limit: int = None,
+                                           order_by: str = 'DESC'):
     pass
 
 @router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['metrics'])

--- a/backend/bloom/routers/metrics.py
+++ b/backend/bloom/routers/metrics.py
@@ -6,7 +6,7 @@ from bloom.logger import logger
 from pydantic import BaseModel, Field
 from typing_extensions import Annotated, Literal, Optional
 from datetime import datetime, timedelta
-from sqlalchemy import select, func, and_, or_
+from sqlalchemy import select, func, and_, or_, text, literal_column, Row
 from bloom.infra.database import sql_model
 from bloom.infra.repositories.repository_segment import SegmentRepository
 from sqlalchemy.ext.serializer import loads,dumps
@@ -15,11 +15,13 @@ import time
 from bloom.infra.database.database_manager import Base
 from bloom.domain.metrics import (ResponseMetricsVesselInActivitySchema,
                                  ResponseMetricsZoneVisitedSchema,
-                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
+                                 ResponseMetricsZoneVisitingTimeByVesselSchema,
+                                 ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema)
 from bloom.domain.api import (  DatetimeRangeRequest,
                                 PaginatedRequest,OrderByRequest,OrderByEnum,
                                 paginate,PagedResponseSchema,PageParams,
-                                X_API_KEY_HEADER, check_apikey,CachedRequest)
+                                X_API_KEY_HEADER, check_apikey,CachedRequest,
+                                TotalTimeActivityTypeRequest)
 
 router = APIRouter()
 rd = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
@@ -46,23 +48,23 @@ def read_metrics_vessels_in_activity_total(request: Request,
             payload=loads(cache_payload)
     else:
         with db.session() as session:
-            stmt=select(sql_model.Vessel.id,
-                        sql_model.Vessel.mmsi,
-                        sql_model.Vessel.ship_name,
-                        sql_model.Vessel.width,
-                        sql_model.Vessel.length,
-                        sql_model.Vessel.country_iso3,
-                        sql_model.Vessel.type,
-                        sql_model.Vessel.imo,
-                        sql_model.Vessel.cfr,
-                        sql_model.Vessel.external_marking,
-                        sql_model.Vessel.ircs,
-                        sql_model.Vessel.home_port_id,
-                        sql_model.Vessel.details,
-                        sql_model.Vessel.tracking_activated,
-                        sql_model.Vessel.tracking_status,
-                        sql_model.Vessel.length_class,
-                        sql_model.Vessel.check,
+            stmt=select(sql_model.Vessel.id.label("vessel_id"),
+                        sql_model.Vessel.mmsi.label("vessel_mmsi"),
+                        sql_model.Vessel.ship_name.label("vessel_ship_name"),
+                        sql_model.Vessel.width.label("vessel_width"),
+                        sql_model.Vessel.length.label("vessel_length"),
+                        sql_model.Vessel.country_iso3.label("vessel_country_iso3"),
+                        sql_model.Vessel.type.label("vessel_type"),
+                        sql_model.Vessel.imo.label("vessel_imo"),
+                        sql_model.Vessel.cfr.label("vessel_cfr"),
+                        sql_model.Vessel.external_marking.label("vessel_external_marking"),
+                        sql_model.Vessel.ircs.label("vessel_ircs"),
+                        sql_model.Vessel.home_port_id.label("vessel_home_port_id"),
+                        sql_model.Vessel.details.label("vessel_details"),
+                        sql_model.Vessel.tracking_activated.label("vessel_tracking_activated"),
+                        sql_model.Vessel.tracking_status.label("vessel_tracking_status"),
+                        sql_model.Vessel.length_class.label("vessel_length_class"),
+                        sql_model.Vessel.check.label("vessel_check"),
                         func.sum(sql_model.Excursion.total_time_at_sea).label("total_time_at_sea")
                         )\
                 .select_from(sql_model.Segment)\
@@ -75,19 +77,17 @@ def read_metrics_vessels_in_activity_total(request: Request,
                             sql_model.Excursion.arrival_at == None))
                 )\
                 .group_by(sql_model.Vessel.id,sql_model.Excursion.total_time_at_sea)
-            stmt = stmt.limit(pagination.limit) if pagination.limit != None else stmt
             stmt = stmt.offset(pagination.offset) if pagination.offset != None else stmt
             stmt =  stmt.order_by(sql_model.Excursion.total_time_at_sea.asc())\
                     if  order.order == OrderByEnum.ascending \
-                    else stmt.order_by(sql_model.Excursion.total_time_at_sea.desc())"""
+                    else stmt.order_by(sql_model.Excursion.total_time_at_sea.desc())
+            stmt = stmt.limit(pagination.limit) if pagination.limit != None else stmt
             payload=session.execute(stmt).all()
-            for item in session.execute(stmt).scalars():
-                print(f"{item.vessel_id},{item.total_time_at_sea}")
             serialized=dumps(payload)
             rd.set(cache_key, serialized)
             rd.expire(cache_key,settings.redis_cache_expiration)
     logger.debug(f"{cache_key} elapsed Time: {time.time()-start}")
-    return []
+    return payload
 
 @router.get("/metrics/zone-visited",
             response_model=list[ResponseMetricsZoneVisitedSchema],
@@ -118,16 +118,21 @@ def read_metrics_vessels_in_activity_total(request: Request,
                 sql_model.Zone.name.label("zone_name"),
                 func.sum(sql_model.Segment.segment_duration).label("visiting_duration")
                 )\
+                .select_from(sql_model.Zone)\
+                .join(sql_model.RelSegmentZone,sql_model.RelSegmentZone.zone_id == sql_model.Zone.id)\
+                .join(sql_model.Segment,sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
                 .where(
                     or_(
                         sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
                         sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at),)
                 )\
                 .group_by(sql_model.Zone.id)
-            stmt = stmt.limit(pagination.limit) if pagination.limit != None else stmt
-            stmt =  stmt.order_by("visiting_duration")\
+            stmt =  stmt.order_by(func.sum(sql_model.Segment.segment_duration).asc())\
                     if  order.order == OrderByEnum.ascending \
-                    else stmt.order_by("visiting_duration") 
+                    else stmt.order_by(func.sum(sql_model.Segment.segment_duration).desc())
+            stmt = stmt.offset(pagination.offset) if pagination.offset != None else stmt
+            stmt = stmt.limit(pagination.limit) if pagination.limit != None else stmt
+            print(stmt)
             payload=session.execute(stmt).all()
             serialized=dumps(payload)
             rd.set(cache_key, serialized)
@@ -138,42 +143,108 @@ def read_metrics_vessels_in_activity_total(request: Request,
 @router.get("/metrics/zones/{zone_id}/visiting-time-by-vessel",
             response_model=list[ResponseMetricsZoneVisitingTimeByVesselSchema],
             tags=['Metrics'])
-def read_metrics_zone_visiting_time_by_vessel(
-                    datetime_range: Annotated[DatetimeRangeRequest,Body()],
-                    zone_id: int,
-                    limit: int = None,
-                    order_by: str = 'DESC',
-                    auth: str = Depends(X_API_KEY_HEADER),):
-    use_cases = UseCases()
-    db = use_cases.db()
-    with db.session() as session:
-        stmt=select(
-            sql_model.Zone.id.label("zone_id"),
-            sql_model.Zone.category.label("zone_category"),
-            sql_model.Zone.sub_category.label("zone_sub_category"),
-            sql_model.Zone.name.label("zone_name"),
-            sql_model.Vessel.id.label("vessel_id"),
-            sql_model.Vessel.ship_name.label("vessel_name"),
-            sql_model.Vessel.type.label("vessel_type"),
-            sql_model.Vessel.length_class.label("vessel_length_class"),
-            func.sum(sql_model.Segment.segment_duration).label("zone_visiting_time_by_vessel")
-        )\
-        .select_from(sql_model.Zone)\
-        .join(sql_model.RelSegmentZone, sql_model.RelSegmentZone.zone_id == sql_model.Zone.id)\
-        .join(sql_model.Segment, sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
-        .join(sql_model.Excursion, sql_model.Excursion.id == sql_model.Segment.excursion_id)\
-        .join(sql_model.Vessel, sql_model.Excursion.vessel_id == sql_model.Vessel.id)\
-        .where(sql_model.Zone.id == zone_id)\
-        .group_by(sql_model.Zone.id,sql_model.Vessel.id)
-        return  session.execute(stmt).all()
+def read_metrics_zone_visiting_time_by_vessel(request: Request,
+                                            zone_id: int,
+                                            datetime_range: DatetimeRangeRequest = Depends(),
+                                            pagination: PageParams = Depends(),
+                                            order: OrderByRequest = Depends(),
+                                            caching: CachedRequest = Depends(),
+                                            key: str = Depends(X_API_KEY_HEADER),):
+    check_apikey(key)
+    cache_key=f"{request.url.path}?{request.query_params}"
+    cache_payload= rd.get(cache_key)
+    start = time.time()
+    payload=[]
+    if cache_payload and not caching.nocache:
+            logger.debug(f"{cache_key} cached ({settings.redis_cache_expiration})s")
+            payload=loads(cache_payload)
+    else:
+        use_cases = UseCases()
+        db = use_cases.db()
+        with db.session() as session:
+            stmt=select(
+                sql_model.Zone.id.label("zone_id"),
+                sql_model.Zone.category.label("zone_category"),
+                sql_model.Zone.sub_category.label("zone_sub_category"),
+                sql_model.Zone.name.label("zone_name"),
+                sql_model.Vessel.id.label("vessel_id"),
+                sql_model.Vessel.ship_name.label("vessel_name"),
+                sql_model.Vessel.type.label("vessel_type"),
+                sql_model.Vessel.length_class.label("vessel_length_class"),
+                func.sum(sql_model.Segment.segment_duration).label("zone_visiting_time_by_vessel")
+            )\
+            .select_from(sql_model.Zone)\
+            .join(sql_model.RelSegmentZone, sql_model.RelSegmentZone.zone_id == sql_model.Zone.id)\
+            .join(sql_model.Segment, sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
+            .join(sql_model.Excursion, sql_model.Excursion.id == sql_model.Segment.excursion_id)\
+            .join(sql_model.Vessel, sql_model.Excursion.vessel_id == sql_model.Vessel.id)\
+            .where(
+                and_(sql_model.Zone.id == zone_id,
+                    or_(
+                        sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
+                        sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at),))
+                )\
+            .group_by(sql_model.Zone.id,sql_model.Vessel.id)
+            
+            stmt =  stmt.order_by(func.sum(sql_model.Segment.segment_duration).asc())\
+                    if  order.order == OrderByEnum.ascending \
+                    else stmt.order_by(func.sum(sql_model.Segment.segment_duration).desc())
+            stmt = stmt.offset(pagination.offset) if pagination.offset != None else stmt
+            stmt = stmt.limit(pagination.limit) if pagination.limit != None else stmt
+
+            payload=session.execute(stmt).all()
+            serialized=dumps(payload)
+            rd.set(cache_key, serialized)
+            rd.expire(cache_key,settings.redis_cache_expiration)
+    logger.debug(f"{cache_key} elapsed Time: {time.time()-start}")
+    return payload
 
 
+@router.get("/metrics/vessels/{vessel_id}/activity/{activity_type}",
+            response_model=ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema,
+            tags=['Metrics'])
+def read_metrics_vessels_visits_by_activity_type(request: Request,
+                                            vessel_id: int,
+                                            activity_type: TotalTimeActivityTypeRequest = Depends(),
+                                            datetime_range: DatetimeRangeRequest = Depends(),
+                                            #pagination: PageParams = Depends(),
+                                            #order: OrderByRequest = Depends(),
+                                            caching: CachedRequest = Depends(),
+                                            key: str = Depends(X_API_KEY_HEADER),):
+    check_apikey(key)
+    cache_key=f"{request.url.path}?{request.query_params}"
+    cache_payload= rd.get(cache_key)
+    start = time.time()
+    payload=[]
+    if cache_payload and not caching.nocache:
+            logger.debug(f"{cache_key} cached ({settings.redis_cache_expiration})s")
+            payload=loads(cache_payload)
+    else:
+        use_cases = UseCases()
+        db = use_cases.db()
+        with db.session() as session:
+            stmt=select(sql_model.Excursion.vessel_id,
+                        literal_column(f"'{activity_type.type.value}'").label('activity'),
+                        func.sum(sql_model.Excursion.total_time_at_sea).label("total_activity_time")
+                        )\
+                .select_from(sql_model.Excursion)\
+                .where(
+                and_(sql_model.Excursion.vessel_id == vessel_id,
+                    or_(
+                        sql_model.Excursion.departure_at.between(datetime_range.start_at,datetime_range.end_at),
+                        sql_model.Excursion.arrival_at.between(datetime_range.start_at,datetime_range.end_at),))
+                )\
+                .group_by(sql_model.Excursion.vessel_id)\
+                .union(select(
+                    literal_column(vessel_id),
+                    literal_column(f"'{activity_type.type.value}'"),
+                    literal_column('0 seconds'),
+                ))
+            print(type(session.execute(stmt.limit(1)).all()[0]))
+            payload=session.execute(stmt.limit(1)).all()[0]
+            serialized=dumps(payload)
+            rd.set(cache_key, serialized)
+            rd.expire(cache_key,settings.redis_cache_expiration)
 
-@router.get("/metrics/vessels/{vessel_id}/visits/{visit_type}", tags=['Metrics'])
-def read_metrics_vessels_visits_by_visit_type(
-        vessel_id: int,
-        visit_type: str,
-        datetime_range: DatetimeRangeRequest = Depends(),
-        pagination: PaginatedRequest = Depends(),
-        auth: str = Depends(X_API_KEY_HEADER),):
-    pass
+    logger.debug(f"{cache_key} elapsed Time: {time.time()-start}")
+    return payload

--- a/backend/bloom/routers/ports.py
+++ b/backend/bloom/routers/ports.py
@@ -1,0 +1,63 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from redis import Redis
+from bloom.config import settings
+from bloom.container import UseCases
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+import time
+import redis
+import json
+from sqlalchemy import select, func, and_, or_
+from bloom.infra.database import sql_model
+from bloom.infra.repositories.repository_segment import SegmentRepository
+from bloom.config import settings
+from bloom.container import UseCases
+from bloom.domain.vessel import Vessel
+from bloom.logger import logger
+from bloom.domain.metrics import (ResponseMetricsVesselInActiviySchema,
+                                 ResponseMetricsZoneVisitedSchema,
+                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
+from bloom.domain.api import (  DatetimeRangeRequest,
+                                PaginatedRequest,OrderByRequest,OrderByEnum,
+                                paginate,PagedResponseSchema,PageParams,
+                                X_API_KEY_HEADER,check_apikey)
+from bloom.config import settings
+
+router = APIRouter()
+rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
+@router.get("/ports",
+         tags=['Ports'])
+async def list_ports(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/ports"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        port_repository = use_cases.port_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(p.model_dump_json() if p else "{}")
+                         for p in port_repository.get_all_ports(session)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+    
+
+@router.get("/ports/{port_id}",
+         tags=['Ports'])
+async def get_port(port_id:int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    port_repository = use_cases.port_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return port_repository.get_port_by_id(session,port_id)

--- a/backend/bloom/routers/vessels.py
+++ b/backend/bloom/routers/vessels.py
@@ -15,9 +15,6 @@ from bloom.config import settings
 from bloom.container import UseCases
 from bloom.domain.vessel import Vessel
 from bloom.logger import logger
-from bloom.domain.metrics import (ResponseMetricsVesselInActiviySchema,
-                                 ResponseMetricsZoneVisitedSchema,
-                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
 from bloom.domain.api import (  DatetimeRangeRequest,
                                 PaginatedRequest,OrderByRequest,OrderByEnum,
                                 paginate,PagedResponseSchema,PageParams,
@@ -29,7 +26,6 @@ rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 @router.get("/vessels",
             tags=['Vessels'])
 async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    print(f"KEY:{key}")
     check_apikey(key)
     endpoint=f"/vessels"
     cache= rd.get(endpoint)
@@ -111,7 +107,11 @@ async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str =
 
 @router.get("/vessels/{vessel_id}/excursions",
             tags=['Vessels'])
-async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+async def list_vessel_excursions(vessel_id: int, nocache:bool=False,
+                                datetime_range: DatetimeRangeRequest = Depends(),
+                                pagination: PageParams = Depends(),
+                                order: OrderByRequest = Depends(),
+                                key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/{vessel_id}/excursions"
     cache= rd.get(endpoint)
@@ -147,7 +147,9 @@ async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depe
 
 @router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments",
             tags=['Vessels'])
-async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
+async def list_vessel_excursion_segments(vessel_id: int,
+                                         excursions_id: int,
+                                         key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     segment_repository = use_cases.segment_repository()
@@ -157,7 +159,10 @@ async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: 
 
 @router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}",
             tags=['Vessels'])
-async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segment_id:int,key: str = Depends(X_API_KEY_HEADER)):
+async def get_vessel_excursion_segment(vessel_id: int,
+                                       excursions_id: int,
+                                       segment_id:int,
+                                       key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     segment_repository = use_cases.segment_repository()

--- a/backend/bloom/routers/vessels.py
+++ b/backend/bloom/routers/vessels.py
@@ -1,0 +1,166 @@
+from fastapi import APIRouter, Depends, HTTPException
+from redis import Redis
+from bloom.config import settings
+from bloom.container import UseCases
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+import time
+import redis
+import json
+from sqlalchemy import select, func, and_, or_
+from bloom.infra.database import sql_model
+from bloom.infra.repositories.repository_segment import SegmentRepository
+from bloom.config import settings
+from bloom.container import UseCases
+from bloom.domain.vessel import Vessel
+from bloom.logger import logger
+from bloom.domain.metrics import (ResponseMetricsVesselInActiviySchema,
+                                 ResponseMetricsZoneVisitedSchema,
+                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
+from bloom.domain.api import (  DatetimeRangeRequest,
+                                PaginatedRequest,OrderByRequest,OrderByEnum,
+                                paginate,PagedResponseSchema,PageParams,
+                                X_API_KEY_HEADER,check_apikey)
+
+router = APIRouter()
+rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
+@router.get("/vessels",
+            tags=['Vessels'])
+async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    print(f"KEY:{key}")
+    check_apikey(key)
+    endpoint=f"/vessels"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        vessel_repository = use_cases.vessel_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            
+            json_data = [json.loads(v.model_dump_json() if v else "{}")
+                            for v in vessel_repository.get_vessels_list(session)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            return json_data
+
+@router.get("/vessels/{vessel_id}",
+            tags=['Vessels'])
+async def get_vessel(vessel_id: int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    vessel_repository = use_cases.vessel_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return vessel_repository.get_vessel_by_id(session,vessel_id)
+
+@router.get("/vessels/all/positions/last",
+            tags=['Vessels'])
+async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/vessels/all/positions/last"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        segment_repository = use_cases.segment_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(p.model_dump_json() if p else "{}")
+                         for p in segment_repository.get_all_vessels_last_position(session)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+
+@router.get("/vessels/{vessel_id}/positions/last",
+            tags=['Vessels'])
+async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/vessels/{vessel_id}/positions/last"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        segment_repository = use_cases.segment_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            result=segment_repository.get_vessel_last_position(session,vessel_id)
+            json_data = json.loads(result.model_dump_json() if result else "{}")
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+
+@router.get("/vessels/{vessel_id}/excursions",
+            tags=['Vessels'])
+async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/vessels/{vessel_id}/excursions"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        excursion_repository = use_cases.excursion_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(p.model_dump_json() if p else "{}")
+                         for p in excursion_repository.get_excursions_by_vessel_id(session,vessel_id)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return json_data
+
+
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}",
+            tags=['Vessels'])
+async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    excursion_repository = use_cases.excursion_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return excursion_repository.get_vessel_excursion_by_id(session,vessel_id,excursions_id)
+
+
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments",
+            tags=['Vessels'])
+async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    segment_repository = use_cases.segment_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return segment_repository.list_vessel_excursion_segments(session,vessel_id,excursions_id)
+
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}",
+            tags=['Vessels'])
+async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segment_id:int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    segment_repository = use_cases.segment_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return segment_repository.get_vessel_excursion_segment_by_id(session,vessel_id,excursions_id,segment_id)

--- a/backend/bloom/routers/zones.py
+++ b/backend/bloom/routers/zones.py
@@ -15,9 +15,6 @@ from bloom.config import settings
 from bloom.container import UseCases
 from bloom.domain.vessel import Vessel
 from bloom.logger import logger
-from bloom.domain.metrics import (ResponseMetricsVesselInActiviySchema,
-                                 ResponseMetricsZoneVisitedSchema,
-                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
 from bloom.domain.api import (  DatetimeRangeRequest,
                                 PaginatedRequest,OrderByRequest,OrderByEnum,
                                 paginate,PagedResponseSchema,PageParams,

--- a/backend/bloom/routers/zones.py
+++ b/backend/bloom/routers/zones.py
@@ -1,0 +1,133 @@
+from fastapi import APIRouter, Depends, HTTPException, Request
+from redis import Redis
+from bloom.config import settings
+from bloom.container import UseCases
+from pydantic import BaseModel, Field
+from typing_extensions import Annotated, Literal, Optional
+from datetime import datetime, timedelta
+import time
+import redis
+import json
+from sqlalchemy import select, func, and_, or_
+from bloom.infra.database import sql_model
+from bloom.infra.repositories.repository_segment import SegmentRepository
+from bloom.config import settings
+from bloom.container import UseCases
+from bloom.domain.vessel import Vessel
+from bloom.logger import logger
+from bloom.domain.metrics import (ResponseMetricsVesselInActiviySchema,
+                                 ResponseMetricsZoneVisitedSchema,
+                                 ResponseMetricsZoneVisitingTimeByVesselSchema)
+from bloom.domain.api import (  DatetimeRangeRequest,
+                                PaginatedRequest,OrderByRequest,OrderByEnum,
+                                paginate,PagedResponseSchema,PageParams,
+                                X_API_KEY_HEADER,check_apikey)
+
+router = APIRouter()
+rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
+@router.get("/zones",
+            tags=["Zones"])
+async def list_zones(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)  
+    endpoint=f"/zones"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        zone_repository = use_cases.zone_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(z.model_dump_json() if z else "{}")
+                         for z in zone_repository.get_all_zones(session)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+
+@router.get("/zones/all/categories",
+            tags=["Zones"])
+async def list_zone_categories(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/zones/all/categories" 
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        zone_repository = use_cases.zone_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(z.model_dump_json()  if z else "{}")
+                         for z in zone_repository.get_all_zone_categories(session)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+
+@router.get("/zones/by-category/{category}/by-sub-category/{sub}",
+            tags=["Zones"])
+async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/zones/by-category/{category}/by-sub-category/{sub}"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        zone_repository = use_cases.zone_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(z.model_dump_json() if z else "{}")
+                         for z in zone_repository.get_all_zones_by_category(session,category if category != 'all' else None,sub)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+
+@router.get("/zones/by-category/{category}",
+            tags=["Zones"])
+async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    endpoint=f"/zones/by-category/{category}"
+    cache= rd.get(endpoint)
+    start = time.time()
+    if cache and not nocache:
+        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
+        payload=json.loads(cache)
+        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+        return payload
+    else:
+        use_cases = UseCases()
+        zone_repository = use_cases.zone_repository()
+        db = use_cases.db()
+        with db.session() as session:
+            json_data = [json.loads(z.model_dump_json() if z else "{}")
+                         for z in zone_repository.get_all_zones_by_category(session,category if category != 'all' else None)]
+            rd.set(endpoint, json.dumps(json_data))
+            rd.expire(endpoint,settings.redis_cache_expiration)
+            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
+            return json_data
+        
+@router.get("/zones/{zones_id}",
+            tags=["Zones"])
+async def get_zone(zones_id:int,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    zone_repository = use_cases.zone_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return zone_repository.get_zone_by_id(session,zones_id)

--- a/backend/bloom/services/api.py
+++ b/backend/bloom/services/api.py
@@ -3,10 +3,13 @@ from fastapi import Request
 from fastapi.security import APIKeyHeader
 
 from bloom.routers.metrics import router as router_metrics
+from bloom.routers.vessels import router as router_vessels
+from bloom.routers.ports import router as router_ports
+from bloom.routers.zones import router as router_zones
 from bloom.domain.api import (  DatetimeRangeRequest,
                                  PaginatedRequest,OrderByRequest,
                                  paginate,PagedResponseSchema,PageParams,
-                                 X_API_KEY_HEADER)
+                                 X_API_KEY_HEADER,check_apikey)
 
 import redis
 import json
@@ -23,282 +26,17 @@ import time
 
 app = FastAPI()
 app.include_router(router_metrics)
+app.include_router(router_vessels)
+app.include_router(router_ports)
+app.include_router(router_zones)
 
-def check_apikey(key:str):
-    if key != settings.api_key :
-        raise HTTPException(status_code=401, detail="Unauthorized")
-    return True
+
 
 @app.get("/cache/all/flush")
 async def cache_all_flush(request:Request,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     rd.flushall()
     return {"code":0}
-
-@app.get("/vessels")
-async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    print(f"KEY:{key}")
-    check_apikey(key)
-    endpoint=f"/vessels"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        vessel_repository = use_cases.vessel_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            
-            json_data = [json.loads(v.model_dump_json() if v else "{}")
-                            for v in vessel_repository.get_vessels_list(session)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            return json_data
-
-@app.get("/vessels/{vessel_id}")
-async def get_vessel(vessel_id: int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    vessel_repository = use_cases.vessel_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return vessel_repository.get_vessel_by_id(session,vessel_id)
-
-@app.get("/vessels/all/positions/last")
-async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/vessels/all/positions/last"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        segment_repository = use_cases.segment_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(p.model_dump_json() if p else "{}")
-                         for p in segment_repository.get_all_vessels_last_position(session)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-
-@app.get("/vessels/{vessel_id}/positions/last")
-async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/vessels/{vessel_id}/positions/last"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        segment_repository = use_cases.segment_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            result=segment_repository.get_vessel_last_position(session,vessel_id)
-            json_data = json.loads(result.model_dump_json() if result else "{}")
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-
-@app.get("/vessels/{vessel_id}/excursions")
-async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/vessels/{vessel_id}/excursions"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        excursion_repository = use_cases.excursion_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(p.model_dump_json() if p else "{}")
-                         for p in excursion_repository.get_excursions_by_vessel_id(session,vessel_id)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return json_data
-
-
-@app.get("/vessels/{vessel_id}/excursions/{excursions_id}")
-async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    excursion_repository = use_cases.excursion_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return excursion_repository.get_vessel_excursion_by_id(session,vessel_id,excursions_id)
-
-
-@app.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments")
-async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    segment_repository = use_cases.segment_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return segment_repository.list_vessel_excursion_segments(session,vessel_id,excursions_id)
-
-@app.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}")
-async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segment_id:int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    segment_repository = use_cases.segment_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return segment_repository.get_vessel_excursion_segment_by_id(session,vessel_id,excursions_id,segment_id)
-
-@app.get("/ports")
-async def list_ports(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/ports"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        port_repository = use_cases.port_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(p.model_dump_json() if p else "{}")
-                         for p in port_repository.get_all_ports(session)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-    
-
-@app.get("/ports/{port_id}")
-async def get_port(port_id:int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    port_repository = use_cases.port_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return port_repository.get_port_by_id(session,port_id)
-
-@app.get("/zones")
-async def list_zones(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)  
-    endpoint=f"/zones"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        zone_repository = use_cases.zone_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(z.model_dump_json() if z else "{}")
-                         for z in zone_repository.get_all_zones(session)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-
-@app.get("/zones/all/categories")
-async def list_zone_categories(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/zones/all/categories" 
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        zone_repository = use_cases.zone_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(z.model_dump_json()  if z else "{}")
-                         for z in zone_repository.get_all_zone_categories(session)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-
-@app.get("/zones/by-category/{category}/by-sub-category/{sub}")
-async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/zones/by-category/{category}/by-sub-category/{sub}"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        zone_repository = use_cases.zone_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(z.model_dump_json() if z else "{}")
-                         for z in zone_repository.get_all_zones_by_category(session,category if category != 'all' else None,sub)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-
-@app.get("/zones/by-category/{category}")
-async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    endpoint=f"/zones/by-category/{category}"
-    cache= rd.get(endpoint)
-    start = time.time()
-    if cache and not nocache:
-        logger.debug(f"{endpoint} cached ({settings.redis_cache_expiration})s")
-        payload=json.loads(cache)
-        logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-        return payload
-    else:
-        use_cases = UseCases()
-        zone_repository = use_cases.zone_repository()
-        db = use_cases.db()
-        with db.session() as session:
-            json_data = [json.loads(z.model_dump_json() if z else "{}")
-                         for z in zone_repository.get_all_zones_by_category(session,category if category != 'all' else None)]
-            rd.set(endpoint, json.dumps(json_data))
-            rd.expire(endpoint,settings.redis_cache_expiration)
-            logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
-            return json_data
-        
-@app.get("/zones/{zones_id}")
-async def get_zone(zones_id:int,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    use_cases = UseCases()
-    zone_repository = use_cases.zone_repository()
-    db = use_cases.db()
-    with db.session() as session:
-        return zone_repository.get_zone_by_id(session,zones_id)
 
 @app.get("/")
 async def root(request:Request):

--- a/backend/bloom/services/api.py
+++ b/backend/bloom/services/api.py
@@ -2,6 +2,8 @@ from fastapi import FastAPI, APIRouter, Depends, HTTPException
 from fastapi import Request
 from fastapi.security import APIKeyHeader
 
+from bloom.routers.metrics import router as router_metrics
+
 header_scheme = APIKeyHeader(name="x-key")
 
 import redis
@@ -18,6 +20,7 @@ import time
 
 
 app = FastAPI()
+app.include_router(router_metrics)
 
 def check_apikey(key:str):
     if key != settings.api_key :

--- a/backend/bloom/services/api.py
+++ b/backend/bloom/services/api.py
@@ -3,8 +3,10 @@ from fastapi import Request
 from fastapi.security import APIKeyHeader
 
 from bloom.routers.metrics import router as router_metrics
-
-header_scheme = APIKeyHeader(name="x-key")
+from bloom.domain.api import (  DatetimeRangeRequest,
+                                 PaginatedRequest,OrderByRequest,
+                                 paginate,PagedResponseSchema,PageParams,
+                                 X_API_KEY_HEADER)
 
 import redis
 import json
@@ -28,13 +30,14 @@ def check_apikey(key:str):
     return True
 
 @app.get("/cache/all/flush")
-async def cache_all_flush(request:Request,key: str = Depends(header_scheme)):
+async def cache_all_flush(request:Request,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     rd.flushall()
     return {"code":0}
 
 @app.get("/vessels")
-async def list_vessels(nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
+    print(f"KEY:{key}")
     check_apikey(key)
     endpoint=f"/vessels"
     cache= rd.get(endpoint)
@@ -57,7 +60,7 @@ async def list_vessels(nocache:bool=False,key: str = Depends(header_scheme)):
             return json_data
 
 @app.get("/vessels/{vessel_id}")
-async def get_vessel(vessel_id: int,key: str = Depends(header_scheme)):
+async def get_vessel(vessel_id: int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     vessel_repository = use_cases.vessel_repository()
@@ -66,7 +69,7 @@ async def get_vessel(vessel_id: int,key: str = Depends(header_scheme)):
         return vessel_repository.get_vessel_by_id(session,vessel_id)
 
 @app.get("/vessels/all/positions/last")
-async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/all/positions/last"
     cache= rd.get(endpoint)
@@ -89,7 +92,7 @@ async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(he
             return json_data
 
 @app.get("/vessels/{vessel_id}/positions/last")
-async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str = Depends(header_scheme)):
+async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/{vessel_id}/positions/last"
     cache= rd.get(endpoint)
@@ -112,7 +115,7 @@ async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str =
             return json_data
 
 @app.get("/vessels/{vessel_id}/excursions")
-async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/{vessel_id}/excursions"
     cache= rd.get(endpoint)
@@ -136,7 +139,7 @@ async def list_vessel_excursions(vessel_id: int, nocache:bool=False,key: str = D
 
 
 @app.get("/vessels/{vessel_id}/excursions/{excursions_id}")
-async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depends(header_scheme)):
+async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     excursion_repository = use_cases.excursion_repository()
@@ -146,7 +149,7 @@ async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depe
 
 
 @app.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments")
-async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: str = Depends(header_scheme)):
+async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     segment_repository = use_cases.segment_repository()
@@ -155,7 +158,7 @@ async def list_vessel_excursion_segments(vessel_id: int,excursions_id: int,key: 
         return segment_repository.list_vessel_excursion_segments(session,vessel_id,excursions_id)
 
 @app.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}")
-async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segment_id:int,key: str = Depends(header_scheme)):
+async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segment_id:int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     segment_repository = use_cases.segment_repository()
@@ -164,7 +167,7 @@ async def get_vessel_excursion_segment(vessel_id: int,excursions_id: int, segmen
         return segment_repository.get_vessel_excursion_segment_by_id(session,vessel_id,excursions_id,segment_id)
 
 @app.get("/ports")
-async def list_ports(request:Request,nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_ports(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/ports"
     cache= rd.get(endpoint)
@@ -188,7 +191,7 @@ async def list_ports(request:Request,nocache:bool=False,key: str = Depends(heade
     
 
 @app.get("/ports/{port_id}")
-async def get_port(port_id:int,key: str = Depends(header_scheme)):
+async def get_port(port_id:int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     port_repository = use_cases.port_repository()
@@ -197,7 +200,7 @@ async def get_port(port_id:int,key: str = Depends(header_scheme)):
         return port_repository.get_port_by_id(session,port_id)
 
 @app.get("/zones")
-async def list_zones(request:Request,nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_zones(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)  
     endpoint=f"/zones"
     cache= rd.get(endpoint)
@@ -220,7 +223,7 @@ async def list_zones(request:Request,nocache:bool=False,key: str = Depends(heade
             return json_data
 
 @app.get("/zones/all/categories")
-async def list_zone_categories(request:Request,nocache:bool=False,key: str = Depends(header_scheme)):
+async def list_zone_categories(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/all/categories" 
     cache= rd.get(endpoint)
@@ -243,7 +246,7 @@ async def list_zone_categories(request:Request,nocache:bool=False,key: str = Dep
             return json_data
 
 @app.get("/zones/by-category/{category}/by-sub-category/{sub}")
-async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=False,key: str = Depends(header_scheme)):
+async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/by-category/{category}/by-sub-category/{sub}"
     cache= rd.get(endpoint)
@@ -266,7 +269,7 @@ async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=
             return json_data
 
 @app.get("/zones/by-category/{category}")
-async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: str = Depends(header_scheme)):
+async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/by-category/{category}"
     cache= rd.get(endpoint)
@@ -289,7 +292,7 @@ async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: st
             return json_data
         
 @app.get("/zones/{zones_id}")
-async def get_zone(zones_id:int,key: str = Depends(header_scheme)):
+async def get_zone(zones_id:int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
     zone_repository = use_cases.zone_repository()


### PR DESCRIPTION
METRICS ENDPOINTS
### global
- /metrics/vessels-in-activity/total/{start_at/{end_at}
- /metrics/zone-visited/total/{start_at/{end_at}metrics
### metrics
- /zones/{zone_id}/{zone_types}/visit?limit=N&orderBy=ASC/DESC  > renvoie le visiting time pour les top N vessels dans touts les zones/la zone_id
- /vessels/{vessel_id}/{visit_types|all}/visit?limit=N&orderBy=ASC/DESC  > renvoie le visiting time pour les top N zones pour tous les vessel/le vessel_id
-  ADD temporal filters (start_at, end_at) as Timestamps (start/end included ? GMT+0 ?)
-  define what is the "most visited" criteria