### PR TITLE
feat: add /api/v1 prefix for all API endpoints in prevision of multiple versions

### DIFF
--- a/backend/bloom/main.py
+++ b/backend/bloom/main.py
@@ -2,10 +2,11 @@ from fastapi import FastAPI, APIRouter, Depends, HTTPException
 from fastapi import Request
 from fastapi.security import APIKeyHeader
 
-from bloom.routers.metrics import router as router_metrics
-from bloom.routers.vessels import router as router_vessels
-from bloom.routers.ports import router as router_ports
-from bloom.routers.zones import router as router_zones
+from bloom.routers.v1.cache import router as router_cache_v1
+from bloom.routers.v1.metrics import router as router_metrics_v1
+from bloom.routers.v1.vessels import router as router_vessels_v1
+from bloom.routers.v1.ports import router as router_ports_v1
+from bloom.routers.v1.zones import router as router_zones_v1
 from bloom.dependencies import (  DatetimeRangeRequest,
                                  PaginatedRequest,OrderByRequest,
                                  paginate,PagedResponseSchema,PageParams,
@@ -23,26 +24,31 @@ rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 from datetime import datetime
 import time
 
+API_PREFIX_V1='/api/v1'
 
 app = FastAPI()
-app.include_router(router_metrics)
-app.include_router(router_vessels)
-app.include_router(router_ports)
-app.include_router(router_zones)
 
 
-
-@app.get("/cache/all/flush")
-async def cache_all_flush(request:Request,key: str = Depends(X_API_KEY_HEADER)):
-    check_apikey(key)
-    rd.flushall()
-    return {"code":0}
-
-@app.get("/")
+@app.get("/", include_in_schema=False)
+@app.get("/api", include_in_schema=False)
 async def root(request:Request):
     return {
-            "cache_all_flush": f"{request.url_for('cache_all_flush')}",
+            "v1": f"{request.url_for('root_api_v1')}",
+            }
+
+@app.get("/api/v1", include_in_schema=False)
+async def root_api_v1(request:Request):
+    return {
+            "cache":    f"{request.url_for('cache_all_flush')}",
             "ports":    f"{request.url_for('list_ports')}",
             "vessels":  f"{request.url_for('list_vessels')}",
             "zones":    f"{request.url_for('list_zones')}",
             }
+
+app.include_router(router_cache_v1,prefix=API_PREFIX_V1,tags=["Cache"])
+app.include_router(router_metrics_v1,prefix=API_PREFIX_V1,tags=["Metrics"])
+app.include_router(router_ports_v1,prefix=API_PREFIX_V1,tags=["Ports"])
+app.include_router(router_vessels_v1,prefix=API_PREFIX_V1,tags=["Vessels"])
+app.include_router(router_zones_v1,prefix=API_PREFIX_V1,tags=["Zones"])
+
+

--- a/backend/bloom/routers/v1/cache.py
+++ b/backend/bloom/routers/v1/cache.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, Depends, Request
+from bloom.config import settings
+import redis
+from bloom.config import settings
+from bloom.logger import logger
+from bloom.dependencies import (X_API_KEY_HEADER,check_apikey)
+
+router = APIRouter()
+rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
+
+@router.get("/cache/all/flush")
+async def cache_all_flush(request:Request,key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    rd.flushall()
+    return {"code":0}

--- a/backend/bloom/routers/v1/metrics.py
+++ b/backend/bloom/routers/v1/metrics.py
@@ -28,8 +28,7 @@ router = APIRouter()
 rd = Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
 @router.get("/metrics/vessels-in-activity",
-            response_model=list[ResponseMetricsVesselInActivitySchema],
-            tags=['Metrics'])
+            response_model=list[ResponseMetricsVesselInActivitySchema])
 def read_metrics_vessels_in_activity_total(request: Request,
                                            datetime_range: DatetimeRangeRequest = Depends(),
                                            pagination: PageParams = Depends(),
@@ -58,8 +57,7 @@ def read_metrics_vessels_in_activity_total(request: Request,
     return payload
 
 @router.get("/metrics/zone-visited",
-            response_model=list[ResponseMetricsZoneVisitedSchema],
-            tags=['Metrics'] )
+            response_model=list[ResponseMetricsZoneVisitedSchema])
 def read_zone_visited_total(request: Request,
                                            datetime_range: DatetimeRangeRequest = Depends(),
                                            pagination: PageParams = Depends(),
@@ -87,8 +85,7 @@ def read_zone_visited_total(request: Request,
     return payload
 
 @router.get("/metrics/zones/{zone_id}/visiting-time-by-vessel",
-            response_model=list[ResponseMetricsZoneVisitingTimeByVesselSchema],
-            tags=['Metrics'])
+            response_model=list[ResponseMetricsZoneVisitingTimeByVesselSchema])
 def read_metrics_zone_visiting_time_by_vessel(request: Request,
                                             zone_id: int,
                                             datetime_range: DatetimeRangeRequest = Depends(),
@@ -120,8 +117,7 @@ def read_metrics_zone_visiting_time_by_vessel(request: Request,
 
 
 @router.get("/metrics/vessels/{vessel_id}/activity/{activity_type}",
-            response_model=ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema,
-            tags=['Metrics'])
+            response_model=ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema)
 def read_metrics_vessels_visits_by_activity_type(request: Request,
                                             vessel_id: int,
                                             activity_type: TotalTimeActivityTypeRequest = Depends(),

--- a/backend/bloom/routers/v1/ports.py
+++ b/backend/bloom/routers/v1/ports.py
@@ -24,8 +24,7 @@ from bloom.config import settings
 router = APIRouter()
 rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
-@router.get("/ports",
-         tags=['Ports'])
+@router.get("/ports")
 async def list_ports(   request:Request,
                         caching: CachedRequest = Depends(),
                         key: str = Depends(X_API_KEY_HEADER)):
@@ -51,8 +50,7 @@ async def list_ports(   request:Request,
             return json_data
     
 
-@router.get("/ports/{port_id}",
-         tags=['Ports'])
+@router.get("/ports/{port_id}")
 async def get_port(port_id:int,
                         key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)

--- a/backend/bloom/routers/v1/vessels.py
+++ b/backend/bloom/routers/v1/vessels.py
@@ -23,8 +23,7 @@ from bloom.dependencies import (  DatetimeRangeRequest,
 router = APIRouter()
 rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
-@router.get("/vessels",
-            tags=['Vessels'])
+@router.get("/vessels")
 async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels"
@@ -47,8 +46,7 @@ async def list_vessels(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
             rd.expire(endpoint,settings.redis_cache_expiration)
             return json_data
 
-@router.get("/vessels/{vessel_id}",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}")
 async def get_vessel(vessel_id: int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
@@ -57,8 +55,7 @@ async def get_vessel(vessel_id: int,key: str = Depends(X_API_KEY_HEADER)):
     with db.session() as session:
         return vessel_repository.get_vessel_by_id(session,vessel_id)
 
-@router.get("/vessels/all/positions/last",
-            tags=['Vessels'])
+@router.get("/vessels/all/positions/last")
 async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/all/positions/last"
@@ -81,8 +78,7 @@ async def list_all_vessel_last_position(nocache:bool=False,key: str = Depends(X_
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
 
-@router.get("/vessels/{vessel_id}/positions/last",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}/positions/last")
 async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/vessels/{vessel_id}/positions/last"
@@ -105,8 +101,7 @@ async def get_vessel_last_position(vessel_id: int, nocache:bool=False,key: str =
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
 
-@router.get("/vessels/{vessel_id}/excursions",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}/excursions")
 async def list_vessel_excursions(vessel_id: int, nocache:bool=False,
                                 datetime_range: DatetimeRangeRequest = Depends(),
                                 pagination: PageParams = Depends(),
@@ -134,8 +129,7 @@ async def list_vessel_excursions(vessel_id: int, nocache:bool=False,
         return json_data
 
 
-@router.get("/vessels/{vessel_id}/excursions/{excursions_id}",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}")
 async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()
@@ -145,8 +139,7 @@ async def get_vessel_excursion(vessel_id: int,excursions_id: int,key: str = Depe
         return excursion_repository.get_vessel_excursion_by_id(session,vessel_id,excursions_id)
 
 
-@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments")
 async def list_vessel_excursion_segments(vessel_id: int,
                                          excursions_id: int,
                                          key: str = Depends(X_API_KEY_HEADER)):
@@ -157,8 +150,7 @@ async def list_vessel_excursion_segments(vessel_id: int,
     with db.session() as session:
         return segment_repository.list_vessel_excursion_segments(session,vessel_id,excursions_id)
 
-@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}",
-            tags=['Vessels'])
+@router.get("/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}")
 async def get_vessel_excursion_segment(vessel_id: int,
                                        excursions_id: int,
                                        segment_id:int,

--- a/backend/bloom/routers/v1/zones.py
+++ b/backend/bloom/routers/v1/zones.py
@@ -23,8 +23,7 @@ from bloom.dependencies import (  DatetimeRangeRequest,
 router = APIRouter()
 rd = redis.Redis(host=settings.redis_host, port=settings.redis_port, db=0)
 
-@router.get("/zones",
-            tags=["Zones"])
+@router.get("/zones")
 async def list_zones(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)  
     endpoint=f"/zones"
@@ -47,8 +46,7 @@ async def list_zones(request:Request,nocache:bool=False,key: str = Depends(X_API
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
 
-@router.get("/zones/all/categories",
-            tags=["Zones"])
+@router.get("/zones/all/categories")
 async def list_zone_categories(request:Request,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/all/categories" 
@@ -71,8 +69,7 @@ async def list_zone_categories(request:Request,nocache:bool=False,key: str = Dep
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
 
-@router.get("/zones/by-category/{category}/by-sub-category/{sub}",
-            tags=["Zones"])
+@router.get("/zones/by-category/{category}/by-sub-category/{sub}")
 async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/by-category/{category}/by-sub-category/{sub}"
@@ -95,8 +92,7 @@ async def get_zone_all_by_category(category:str="all",sub:str=None,nocache:bool=
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
 
-@router.get("/zones/by-category/{category}",
-            tags=["Zones"])
+@router.get("/zones/by-category/{category}")
 async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     endpoint=f"/zones/by-category/{category}"
@@ -119,8 +115,7 @@ async def get_zone_all_by_category(category:str="all",nocache:bool=False,key: st
             logger.debug(f"{endpoint} elapsed Time: {time.time()-start}")
             return json_data
         
-@router.get("/zones/{zones_id}",
-            tags=["Zones"])
+@router.get("/zones/{zones_id}")
 async def get_zone(zones_id:int,key: str = Depends(X_API_KEY_HEADER)):
     check_apikey(key)
     use_cases = UseCases()


### PR DESCRIPTION
Ajout d'un prefix /api/v1/... pour tous les endpoints

- /api/v1/cache/all/flush
- /api/v1/metrics/vessels-in-activity
- /api/v1/metrics/zone-visited
- /api/v1/metrics/zones/{zone_id}/visiting-time-by-vessel
- /api/v1/metrics/vessels/{vessel_id}/activity/{activity_type}
- /api/v1/ports
- /api/v1/ports/{port_id}
- /api/v1/vessels
- /api/v1/vessels/{vessel_id}
- /api/v1/vessels/all/positions/last
- /api/v1/vessels/{vessel_id}/positions/last
- /api/v1/vessels/{vessel_id}/excursions
- /api/v1/vessels/{vessel_id}/excursions/{excursions_id}
- /api/v1/vessels/{vessel_id}/excursions/{excursions_id}/segments
- /api/v1/vessels/{vessel_id}/excursions/{excursions_id}/segments/{segment_id}
- /api/v1/zones
- /api/v1/zones/all/categories
- /api/v1/zones/by-category/{category}/by-sub-category/{sub}
- /api/v1/zones/by-category/{category}
- /api/v1/zones/{zones_id}