### PR TITLE
Metrics processing

### DIFF
--- a/backend/alembic/versions/c32d65d6e6fd_create_fct_metrics.py
+++ b/backend/alembic/versions/c32d65d6e6fd_create_fct_metrics.py
@@ -1,0 +1,24 @@
+"""create fct metrics
+
+Revision ID: c32d65d6e6fd
+Revises: 06bb3c26076f
+Create Date: 2024-10-18 11:13:02.468934
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c32d65d6e6fd'
+down_revision = '06bb3c26076f'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/c32d65d6e6fd_create_fct_metrics.py
+++ b/backend/alembic/versions/c32d65d6e6fd_create_fct_metrics.py
@@ -7,7 +7,8 @@ Create Date: 2024-10-18 11:13:02.468934
 """
 from alembic import op
 import sqlalchemy as sa
-
+from sqlalchemy import Inspector
+import geoalchemy2
 
 # revision identifiers, used by Alembic.
 revision = 'c32d65d6e6fd'
@@ -17,8 +18,27 @@ depends_on = None
 
 
 def upgrade() -> None:
-    pass
+
+    # Création de la table fct_metrics
+    op.create_table(
+        'fct_metrics',
+        sa.Column('timestamp', sa.DateTime, primary_key=True), #granule
+        sa.Column('vessel_id', sa.Integer, nullable=False), #vessel id
+        sa.Column('type', sa.String, nullable=False), #in_mpa or at_sea
+        sa.Column('duration_total', sa.DateTime, nullable=False), #time spent at sea at timestamp
+        sa.Column('duration_fishing', sa.DateTime, nullable=True), #time spent fishing 
+        sa.Column("mpa_name", sa.String, nullable=True), # if type is in_mpa, write here the mpa name
+    )
 
 
 def downgrade() -> None:
-    pass
+    # Suppression de la table fct_metrics en cas de rollback
+    conn = op.get_bind()
+    inspector = Inspector.from_engine(conn)
+    sql_tables = inspector.get_table_names()
+    tables = [
+        "fct_metrics",
+    ]
+    for t in tables:
+        if t in sql_tables:
+            op.drop_table(t)


### PR DESCRIPTION
Creation d'une table de faits fct_metrics contenant les informations pour les statistiques. Cette table sera utilisée pour les différents endpoints. L'idée est d'effectuer des pré-calculs replissants cette table. la table contient  Une granularité (un pas de temps) un identifiant de bateau, un type ( soit in amp soit at sea), combien de temps (un timestamp), le nom de la zone (None si le bateau n'était pas en amp) en pêchant ou non (booleen) . Ces informations seront agrégées en fonction des requêtes effectuées via api