### PR TITLE
fix: docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,6 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 ARG UV_PROJECT_ENVIRONMENT=${VIRTUAL_ENV}
 ENV UV_PROJECT_ENVIRONMENT=${VIRTUAL_ENV}
 RUN \
-    . ~/.cargo/env &&\
     cd backend &&\
     uv venv ${VIRTUAL_ENV} &&\
     echo ". ${VIRTUAL_ENV}/bin/activate" >> /root/.bashrc &&\


### PR DESCRIPTION
une erreur à la construction de l'image docker liée à UV
il semble que le comosant cargo n'est plus utilisé et le chargement du fichier ~/.cargo/env génère donc une erreur après installation uv
Le fix consiste simplement à supprimer cette ligne
validé pour des images docker pyhton 3.10 et 3.11