### PR TITLE
[back] add clipped_territorial_seas.csv to loaded files (dim_zones)

### DIFF
--- a/backend/bloom/tasks/load_dim_zone_amp_from_csv.py
+++ b/backend/bloom/tasks/load_dim_zone_amp_from_csv.py
@@ -9,7 +9,7 @@ from bloom.container import UseCases
 from bloom.domain.zone import Zone
 from bloom.logger import logger
 
-FIC_ZONE = ["french_metropolitan_mpas.csv", "fishing_coastal_waters.csv", "territorial_seas.csv"]
+FIC_ZONE = ["french_metropolitan_mpas.csv","fishing_coastal_waters.csv", "territorial_seas.csv","clipped_territorial_seas.csv"]
 
 
 def map_to_domain(row: pd.Series) -> Zone:


### PR DESCRIPTION
rajouter une élément à charger dans load_dim_zone_amp_from_csv.py
Le fichier est hébergé sur le S3 trawlwatch de clever cloud (lien dans le notion)