### PR TITLE
fix: no IMO in vessel activity

### DIFF
--- a/backend/bloom/services/metrics.py
+++ b/backend/bloom/services/metrics.py
@@ -59,7 +59,7 @@ class MetricsService():
             #  item[0] is Vessel
             #  item[1] is total_time_at_sea
         return  [ResponseMetricsVesselInActivitySchema(
-            vessel=VesselListView(**VesselRepository.map_to_domain(item[0]).model_dump()),
+            vessel=VesselRepository.map_to_domain(item[0]).model_dump(),
             total_time_at_sea=item[1]
             )\
             for item in payload]


### PR DESCRIPTION
Des restes de tests de vues retreintes pour les bateaux qui renvoyait un VesselListView au lieu d'un Vessel tout court avec toutes les infos (entre un peu en conflit avec la suppression des données géométrie sur laquelle bosse @SaboniAmine #282 )