### PR TITLE
fix getVesselsInActivity

### DIFF
--- a/backend/bloom/routers/v1/metrics.py
+++ b/backend/bloom/routers/v1/metrics.py
@@ -46,8 +46,20 @@ async def read_metrics_vessels_in_activity_total(request: Request,
     payload=MetricsService.getVesselsInActivity(datetime_range=datetime_range,
                                                 pagination=pagination,
                                                 order=order)
-    
+
     return jsonable_encoder(payload)
+
+
+@router.get("/metrics/vessels-at-sea")
+async def list_vessel_at_sea(
+    request: Request,
+    datetime_range: DatetimeRangeRequest = Depends(),
+    key: str = Depends(X_API_KEY_HEADER),  # used by @cache
+):
+    check_apikey(key)
+    use_cases = UseCases()
+    MetricsService = use_cases.metrics_service()
+    return MetricsService.getVesselsAtSea(datetime_range=datetime_range)
 
 
 @router.get("/metrics/zone-visited")


### PR DESCRIPTION
J'ai corrigé la méthode getVesselsInActivity (on comptait les excursions, pas les navires). Je me retrouve avec un nombre non aberrant de navires en activité pendant une période donnée (1464 au max).

@alexphiev @rv2931 @SebM42 
**-> Est-ce que le résultat de cette méthode va nous servir ?** ou faut-il remplacer la méthode par une méthode qui renvoie juste le nombre de navires actifs comme on en a parlé hier en réunion ?