### PR TITLE
fix/workaround: Segment Out of range float values are not JSON compli…

### DIFF
--- a/backend/bloom/domain/segment.py
+++ b/backend/bloom/domain/segment.py
@@ -10,6 +10,8 @@ class Segment(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True,
         json_encoders = {
                 Geometry: lambda geometry: mapping(geometry),
+                # Waiting to manage INF/NaN values, migrating them to None/null
+                float: lambda val: val if val != 'inf' and val != 'NaN' else None,
             },
     )
     id: Union[int, None] = None


### PR DESCRIPTION
Lié à #288 Internal Server Error segments
Il existe des valeurs INF et NaN dans la table segments, notamment à aux colonnes speed_at_start et speed_at_end
Je propose ce workaround en attendant de savoir quoi en faire
Globalement côté PostgreSQL et python il existe un standard (https://www.postgresql.org/docs/8.2/datatype-numeric.html && https://fr.wikipedia.org/wiki/IEEE_754) qui définit ces valeurs spéciales
Dans Python Pandas comem dans PostgreSQL ces valeurs sont considérées comme des float aux valeurs spéciales cependant côté JSON il n'y a pas d'équivalence
Il y a un peu trois choix:
- faire en sorte de mettre la valeur JSON : undefined
- faire en sorte de mettre la valeur JSON : null
- faire en sorte de mettre la valeur JSON sous forme de chaine de charactère "+infinity" "-infinity" "NaN"
Ou encore
- On considère que ce ne sont pas des valeurs valides en base et donc il faut corriger les process ETL pour ne plus avoir ces valeurs
Si je fais le workaround le risque c'est qu'on aura plus d'erreur 500 qu'on ne détecte plus ces valeurs qui seraient en base via des erreurs 500 et qu'on stocke des valeurs non valides sans les détecter

La 3ème solution revient à déléguer le choix de quoi en faire au frontend