### PR TITLE
fix: 272 [API] endpoint visiting_time_by_vessel : manque MMSI et IMO

### DIFF
--- a/backend/bloom/domain/vessel.py
+++ b/backend/bloom/domain/vessel.py
@@ -27,6 +27,5 @@ class Vessel(BaseModel):
 
 class VesselListView(Vessel):
     details:ClassVar[Union[str, None]] = None
-    imo:ClassVar[Union[int, None]] = None
     cfr:ClassVar[Union[str, None]] = None
     home_port_id:ClassVar[Union[int, None]] = None


### PR DESCRIPTION
Corrige l'issue #272 