### PR TITLE
feat: ajout endpoint /api/v1/vessels/trackedCount

### DIFF
--- a/backend/bloom/infra/repositories/repository_vessel.py
+++ b/backend/bloom/infra/repositories/repository_vessel.py
@@ -15,6 +15,12 @@ class VesselRepository:
     ) -> Callable[..., AbstractContextManager]:
         self.session_factory = session_factory
 
+
+    def get_vessel_tracked_count(self, session: Session) -> int:
+        stmt = select(func.count(sql_model.Vessel.id)).select_from(sql_model.Vessel)\
+            .distinct().where(sql_model.Vessel.tracking_activated == True)
+        return session.execute(stmt).scalar()
+
     def get_vessel_types(self, session: Session) -> list[str]:
         stmt = select(sql_model.Vessel.type).select_from(sql_model.Vessel).distinct()
         return [i for i in session.execute(stmt).scalars()]

--- a/backend/bloom/routers/v1/vessels.py
+++ b/backend/bloom/routers/v1/vessels.py
@@ -13,6 +13,16 @@ from fastapi.encoders import jsonable_encoder
 router = APIRouter()
 
 
+@router.get("/vessels/trackedCount")
+async def list_vessel_tracked(request: Request, # used by @cache
+                       key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    vessel_repository = use_cases.vessel_repository()
+    db = use_cases.db()
+    with db.session() as session:
+        return vessel_repository.get_vessel_tracked_count(session)
+
 @router.get("/vessels/types")
 async def list_vessel_types(request: Request, # used by @cache
                        key: str = Depends(X_API_KEY_HEADER)):


### PR DESCRIPTION
Permet de récupérer le nombre de bateau trackés actuellement
Suite discussion @alexphiev 
lié à l'issue #245