### PR TITLE
feat: ajout endpoint /metrics/vessels/time-by-zone (vessel_id,categor…

### DIFF
--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -31,6 +31,12 @@ class ResponseMetricsZoneVisitingTimeByVesselSchema(BaseModel):
     vessel: VesselListView
     zone_visiting_time_by_vessel: timedelta
 
+
+class ResponseMetricsVesselVisitingTimeByZoneSchema(BaseModel):
+    zone: ZoneListView
+    vessel: VesselListView
+    vessel_visiting_time_by_zone: timedelta
+
 class ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema(BaseModel):
     vessel_id : int
     activity: str

--- a/backend/bloom/routers/v1/metrics.py
+++ b/backend/bloom/routers/v1/metrics.py
@@ -20,6 +20,10 @@ from bloom.domain.metrics import (ResponseMetricsVesselInActivitySchema,
                                  ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema)
 from bloom.routers.requests import DatetimeRangeRequest,OrderByRequest,PageParams,CachedRequest
 from bloom.dependencies import ( X_API_KEY_HEADER, check_apikey,cache)
+from bloom.routers.requests import (
+    RangeHeader,
+    RangeHeaderParser
+)
 
 from bloom.domain.metrics import TotalTimeActivityTypeRequest
 from fastapi.encoders import jsonable_encoder
@@ -80,20 +84,24 @@ async def read_metrics_zone_visiting_time_by_vessel(request: Request,
                                                 order=order)
     return jsonable_encoder(payload)
 
-"""
-@router.get("/metrics/vessels/{vessel_id}/activity/{activity_type}")
-@cache
-async def read_metrics_vessels_visits_by_activity_type(request: Request,
-                                            vessel_id: int,
-                                            activity_type: TotalTimeActivityTypeRequest = Depends(),
+@router.get("/metrics/vessels/time-by-zone")
+#@cache
+async def read_metrics_all_vessels_visiting_time_by_zone(request: Request,
+                                            vessel_id: Optional[int] = None,
+                                            category: Optional[str] = None,
+                                            sub_category: Optional[str] = None,
                                             datetime_range: DatetimeRangeRequest = Depends(),
-                                            caching: CachedRequest = Depends(),
+                                            pagination: PageParams = Depends(),
+                                            order: OrderByRequest = Depends(),
                                             key: str = Depends(X_API_KEY_HEADER),):
     check_apikey(key)
     use_cases = UseCases()
     MetricsService=use_cases.metrics_service()
-    payload=MetricsService.getVesselVisitsByActivityType(
+    payload=MetricsService.getVesselVisitingTimeByZone(
                                                 vessel_id=vessel_id,
-                                                activity_type=activity_type,
-                                                datetime_range=datetime_range)
-    return jsonable_encoder(payload)"""
+                                                datetime_range=datetime_range,
+                                                pagination=pagination,
+                                                order=order,
+                                                category=category,
+                                                sub_category=sub_category)
+    return jsonable_encoder(payload)


### PR DESCRIPTION
En lien avec l'issue #273
ajout endpoint /metrics/vessels/time-by-zone (vessel_id,category,sub_category,order,limit/offset)
Paramètres optionels:
- vessel_id: si null alors la requête réverra les infos pour tous les vessels
- category & sub_category: permet de filtrer les resultats sur des types de zone souhaitées. Du fait que plusieurs zones se cehvauche (territorial et amp par ex) plusieurs zones peuvent avoir les mêmes durées pour un même bateau et une même excursion. Ce paramètre permet donc de cibel les amp par exemple qui elles ne se chevauchent pas trop normalement
- order: tri la réponse par vessel_time_by_zone croissant ou décroissant
- limit/offset: permet de restreindre le nombre et se déplacer dans le résultat

Le Top 10 des zones amp visitée par des bateaux entre deux dates est donc
`category=amp&start_at=2024-11-19T14%3A26%3A59.165380&end_at=2024-11-26T14%3A26%3A59.165444&offset=0&limit=10&order=DESC`

La réponse renvoie la zone et le vessel au format restreint "ListView"
```
[
  {
    "zone": {
      "id": 660,
      "category": "amp",
      "sub_category": "Special Protection Area (Birds Directive)",
      "name": "Mers Celtiques - Talus du golfe de Gascogne",
      "created_at": "2024-11-19T18:24:23.330352Z",
      "updated_at": null,
      "centroid": {
        "type": "Point",
        "coordinates": [
          -6.080380635849015,
          47.34222734315848
        ]
      }
    },
    "vessel": {
      "id": 1043,
      "mmsi": 224103970,
      "ship_name": "RAUL PRIMERO",
      "width": null,
      "length": 33,
      "country_iso3": "ESP",
      "type": "Other",
      "imo": 9031131,
      "external_marking": "3FE-2-3007",
      "ircs": "EADZ",
      "tracking_activated": true,
      "tracking_status": "active",
      "created_at": "2024-07-09T16:20:35.461015Z",
      "updated_at": null,
      "check": "fleet register",
      "length_class": "25-40 m"
    },
    "vessel_visiting_time_by_zone": "P1DT19H23M21S"
  },
  {
    "zone": {
      "id": 653,
      "category": "amp",
      "sub_category": "Sites of Community Importance (Habitats Directive)",
      "name": "Mers Celtiques - Talus du golfe de Gascogne",
      "created_at": "2024-11-19T18:24:23.330352Z",
      "updated_at": null,
      "centroid": {
        "type": "Point",
        "coordinates": [
          -6.224467503328862,
          47.491031271487245
        ]
      }
    },
    "vessel": {
      "id": 1043,
      "mmsi": 224103970,
      "ship_name": "RAUL PRIMERO",
      "width": null,
      "length": 33,
      "country_iso3": "ESP",
      "type": "Other",
      "imo": 9031131,
      "external_marking": "3FE-2-3007",
      "ircs": "EADZ",
      "tracking_activated": true,
      "tracking_status": "active",
      "created_at": "2024-07-09T16:20:35.461015Z",
      "updated_at": null,
      "check": "fleet register",
      "length_class": "25-40 m"
    },
    "vessel_visiting_time_by_zone": "P1DT18H28M44S"
  },
  {
    "zone": {
      "id": 660,
      "category": "amp",
      "sub_category": "Special Protection Area (Birds Directive)",
      "name": "M
```