### PR TITLE
fix: datetime range endpoint + conformisation + pagination/roder sur vessels/id/excursions

### DIFF
--- a/backend/bloom/routers/requests.py
+++ b/backend/bloom/routers/requests.py
@@ -55,7 +55,7 @@ class OrderByEnum(str, Enum):
 
 class DatetimeRangeRequest(BaseModel):
     start_at: datetime = Field(default=datetime.now()-timedelta(days=7))
-    end_at: datetime = datetime.now()
+    end_at: datetime= datetime.now()
 
 class OrderByRequest(BaseModel):
     order: OrderByEnum = OrderByEnum.ascending

--- a/backend/bloom/routers/v1/vessels.py
+++ b/backend/bloom/routers/v1/vessels.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Request
 from redis import Redis
 from bloom.config import settings
 from bloom.container import UseCases
-from typing import Any
+from typing import Any, Optional
 import json
 from bloom.config import settings
 from bloom.container import UseCases
@@ -120,7 +120,7 @@ async def get_vessel_last_position(request: Request, # used by @cache
 async def list_vessel_excursions(request: Request, # used by @cache
                                  vessel_id: int,
                                  nocache:bool=False, # used by @cache
-                                datetime_range: DatetimeRangeRequest = Depends(),
+                                datetime_range: DatetimeRangeRequest= Depends(),
                                 pagination: PageParams = Depends(),
                                 order: OrderByRequest = Depends(),
                                 key: str = Depends(X_API_KEY_HEADER)):
@@ -132,7 +132,12 @@ async def list_vessel_excursions(request: Request, # used by @cache
     json_data={}
     with db.session() as session:
         json_data = [json.loads(p.model_dump_json() if p else "{}")
-                        for p in excursion_repository.get_excursions_by_vessel_id(session,vessel_id, datetime_range)]
+                        for p in excursion_repository.get_excursions_by_vessel_id(
+                                                    session,
+                                                    vessel_id,
+                                                    datetime_range,
+                                                    pagination=pagination,
+                                                    order=order)]
     return json_data
 
 

--- a/backend/bloom/services/metrics.py
+++ b/backend/bloom/services/metrics.py
@@ -49,8 +49,13 @@ class MetricsService():
                     sql_model.Segment.in_amp_zone == True
                 )\
                 .where(
-                        sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
-                        sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at),)\
+                        and_(
+                            sql_model.Segment.timestamp_start <= datetime_range.end_at,
+                            or_(sql_model.Segment.timestamp_end>= datetime_range.start_at,
+                                sql_model.Segment.timestamp_end == None
+                            )
+                        )
+                    )\
                 .group_by(sql_model.Vessel)
             stmt = stmt.offset(pagination.offset) if pagination.offset != None else stmt
             stmt =  stmt.order_by(asc("total_time_in_mpa"))\
@@ -107,10 +112,13 @@ class MetricsService():
                 .join(sql_model.RelSegmentZone,sql_model.RelSegmentZone.zone_id == sql_model.Zone.id)\
                 .join(sql_model.Segment,sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
                 .where(
-                    or_(
-                        sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
-                        sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at))
-                )\
+                        and_(
+                            sql_model.Segment.timestamp_start <= datetime_range.end_at,
+                            or_(sql_model.Segment.timestamp_end>= datetime_range.start_at,
+                                sql_model.Segment.timestamp_end == None
+                            )
+                        )
+                    )\
                 .group_by(sql_model.Zone.id)
             if (category):
                 stmt = stmt.where(sql_model.Zone.category == category)
@@ -148,11 +156,14 @@ class MetricsService():
             .join(sql_model.Segment, sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
             .join(sql_model.Excursion, sql_model.Excursion.id == sql_model.Segment.excursion_id)\
             .join(sql_model.Vessel, sql_model.Excursion.vessel_id == sql_model.Vessel.id)\
+            .where(sql_model.Zone.id == zone_id)\
             .where(
-                and_(sql_model.Zone.id == zone_id,
-                    or_(
-                        sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
-                        sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at),))
+                    and_(
+                        sql_model.Segment.timestamp_start <= datetime_range.end_at,
+                        or_(sql_model.Segment.timestamp_end>= datetime_range.start_at,
+                            sql_model.Segment.timestamp_end == None
+                        )
+                    )
                 )\
             .group_by(sql_model.Zone.id,sql_model.Vessel.id)
             
@@ -195,9 +206,13 @@ class MetricsService():
                 .join(sql_model.RelSegmentZone, sql_model.RelSegmentZone.segment_id == sql_model.Segment.id)\
                 .join(sql_model.Zone, sql_model.Zone.id == sql_model.RelSegmentZone.zone_id)\
                 .where(
-                    or_(sql_model.Segment.timestamp_start.between(datetime_range.start_at,datetime_range.end_at),
-                        sql_model.Segment.timestamp_end.between(datetime_range.start_at,datetime_range.end_at))
-                )\
+                        and_(
+                            sql_model.Segment.timestamp_start <= datetime_range.end_at,
+                            or_(sql_model.Segment.timestamp_end>= datetime_range.start_at,
+                                sql_model.Segment.timestamp_end == None
+                            )
+                        )
+                    )\
                 .group_by(sql_model.Vessel,
                         sql_model.Zone,)
             if category:
@@ -230,12 +245,15 @@ class MetricsService():
                         func.sum(sql_model.Excursion.total_time_at_sea).label("total_activity_time")
                         )\
                 .select_from(sql_model.Excursion)\
+                .where(sql_model.Excursion.vessel_id == vessel_id)\
                 .where(
-                and_(sql_model.Excursion.vessel_id == vessel_id,
-                    or_(
-                        sql_model.Excursion.departure_at.between(datetime_range.start_at,datetime_range.end_at),
-                        sql_model.Excursion.arrival_at.between(datetime_range.start_at,datetime_range.end_at),))
-                )\
+                        and_(
+                            sql_model.Excursion.departure_at <= datetime_range.end_at,
+                            or_(sql_model.Excursion.arrival_at>= datetime_range.start_at,
+                                sql_model.Excursion.arrival_at == None
+                            )
+                        )
+                    )\
                 .group_by(sql_model.Excursion.vessel_id)\
                 .union(select(
                     literal_column(vessel_id),


### PR DESCRIPTION
Mise en conformité des tests datetime_range selon les endpoints + ajout pagination/order pour vessels/id/excrursions

# Conflicts:
#	backend/bloom/infra/repositories/repository_excursion.py #	backend/bloom/routers/v1/vessels.py