### PR TITLE
Config SWR améliorée pour garder les données dashboard en cache

### DIFF
--- a/frontend/services/dashboard.service.ts
+++ b/frontend/services/dashboard.service.ts
@@ -35,7 +35,7 @@ export const useDashboardData = (
     data: topVesselsInActivity = [],
     isLoading: topVesselsInActivityLoading,
   } = useSWR(
-    `topVesselsInActivity-${startAt}-${endAt}`,
+    `topVesselsInActivity-${startAt}`,
     async () => {
       try {
         const response = await getTopVesselsInActivity(
@@ -56,7 +56,7 @@ export const useDashboardData = (
 
   const { data: topAmpsVisited = [], isLoading: topAmpsVisitedLoading } =
     useSWR(
-      `topAmpsVisited-${startAt}-${endAt}`,
+      `topAmpsVisited-${startAt}`,
       async () => {
         try {
           const response = await getTopZonesVisited(
@@ -80,7 +80,7 @@ export const useDashboardData = (
     data: totalVesselsInActivity = 0,
     isLoading: totalVesselsInActivityLoading,
   } = useSWR(
-    `totalVesselsInActivity-${startAt}-${endAt}`,
+    `totalVesselsInActivity-${startAt}`,
     async () => {
       try {
         const response = await getVesselsAtSea(startAt, endAt)
@@ -97,7 +97,7 @@ export const useDashboardData = (
 
   const { data: totalAmpsVisited = 0, isLoading: totalAmpsVisitedLoading } =
     useSWR(
-      `totalAmpsVisited-${startAt}-${endAt}`,
+      `totalAmpsVisited-${startAt}`,
       async () => {
         try {
           const response = await getTopZonesVisited(

--- a/frontend/services/swr.ts
+++ b/frontend/services/swr.ts
@@ -4,4 +4,5 @@ export const swrOptions = {
   dedupingInterval: 1000 * 60 * 60,
   keepPreviousData: true,
   revalidateOnMount: true,
+  revalidateIfStale: false,
 }


### PR DESCRIPTION
Je suspecte que ça ne fonctionnait pas bien à cause de la `endDate` qui changeait constamment.