### PR TITLE
Feat add zone id category metrics

### DIFF
--- a/backend/alembic/versions/2b9d9e61be30_metrics_add_category.py
+++ b/backend/alembic/versions/2b9d9e61be30_metrics_add_category.py
@@ -1,0 +1,43 @@
+"""metrics add category
+
+Revision ID: 2b9d9e61be30
+Revises: c32d65d6e6fd
+Create Date: 2024-12-11 12:33:19.307295
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '2b9d9e61be30'
+down_revision = 'c32d65d6e6fd'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('fct_metrics',sa.Column('zone_id',
+                                            sa.Integer,
+                                            sa.ForeignKey("dim_zone.id"),
+                                            nullable=True))
+    op.add_column('fct_metrics',sa.Column('zone_category',
+                                            sa.String,
+                                            nullable=True))
+    op.execute("""
+               update fct_metrics fm
+               set zone_id = (select id
+                              from dim_zone dz
+                              where name = fm.zone_name and
+                                    (sub_category = fm.zone_sub_category)),
+               zone_category = (select category
+                              from dim_zone dz
+                              where name = fm.zone_name and
+                              (sub_category = fm.zone_sub_category))""")
+    pass
+
+
+def downgrade() -> None:
+    op.drop_column('fct_metrics','zone_category')
+    op.drop_column('fct_metrics','zone_id')
+    pass

--- a/backend/alembic/versions/2b9d9e61be30_metrics_add_category.py
+++ b/backend/alembic/versions/2b9d9e61be30_metrics_add_category.py
@@ -33,7 +33,8 @@ def upgrade() -> None:
                zone_category = (select category
                               from dim_zone dz
                               where name = fm.zone_name and
-                              (sub_category = fm.zone_sub_category))""")
+                              (sub_category = fm.zone_sub_category))
+                where zone_id is null or zone_category is null""")
     pass
 
 

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -19,6 +19,8 @@ class Metrics(BaseModel) :
     duration_total : timedelta
     duration_fishing: Optional[timedelta] = None
     zone_name : str
+    zone_id : Optional[int] = None
+    zone_category : Optional[str] = None
     zone_sub_category : Optional[str] = None
 
 class TotalTimeActivityTypeEnum(str, Enum):

--- a/backend/bloom/infra/database/sql_model.py
+++ b/backend/bloom/infra/database/sql_model.py
@@ -273,5 +273,7 @@ class Metrics(Base):
     duration_total= Column("duration_total", Interval, nullable= False)
     duration_fishing= Column("duration_fishing", Interval)
     zone_name= Column("zone_name", String, ForeignKey("dim_zone.name"),primary_key=True)
+    zone_id= Column("zone_id", Integer, ForeignKey("dim_zone.id"))
+    zone_category= Column("zone_category", String, ForeignKey("dim_zone.category"))
     zone_sub_category= Column("zone_sub_category", String, ForeignKey("dim_zone.sub_category"))
 

--- a/backend/bloom/infra/repositories/repository_metrics.py
+++ b/backend/bloom/infra/repositories/repository_metrics.py
@@ -65,6 +65,8 @@ class MetricsRepository:
             duration_total=metrics.duration_total,
             duration_fishing=metrics.duration_fishing,
             zone_name=metrics.zone_name,
+            zone_id=metrics.zone_id,
+            zone_category=metrics.zone_category,
             zone_sub_category=metrics.zone_sub_category,
         )            
 
@@ -82,6 +84,8 @@ class MetricsRepository:
                 duration_total=metrics.duration_total,
                 duration_fishing=metrics.duration_fishing,
                 zone_name=metrics.zone_name,
+                zone_id=metrics.zone_id,
+                zone_category=metrics.zone_category,
                 zone_sub_category=metrics.zone_sub_category,
             )            
 

--- a/backend/bloom/tasks/create_update_excursions_segments.py
+++ b/backend/bloom/tasks/create_update_excursions_segments.py
@@ -356,6 +356,8 @@ def run():
                     type = types, 
                     duration_total = segment.segment_duration,
                     duration_fishing = segment.segment_duration if segment.type == 'FISHING' else None,
+                    zone_id=zone.id,
+                    zone_category=zone.category,
                     zone_name = zone.name,
                     zone_sub_category=zone.sub_category
                 ) 


### PR DESCRIPTION
Lié au #339

Ajout de zone_id et zone_category afin de permettre de pouvoir retrouver (si besoin) la zone identifiée au niveau de la table metrics
LE souci vient du fait qu'il est possibel de créer aujourd'hui des zone avec le même non et la même sub_category (null notamment), idéalement il est donc nécessaire d'avoir le nom de la catégorie (indirectement via type) ou directement vie cette nouvelel colonne category

Cas problématique par exemple: zone "Mer territoriale au large de la France en Atlantique, Manche et Mer du Nord" qui a deux catégories, mais même nom et sub_category=null

De plus cela permettra d'avoir des statistiques sur de nouvelles catégories de zones avant que celle-ci ne soient complètement prises en compte et typée via la colonne type dans fct_metrics; avoir name,category,sub_category permettra de regénérer facilement la colonne type après coup dans une révision alembic


Utile notamment lorsque la table dim_zone passera en SCD afin de pouvoir retrouver la version de la zone exacte qui aura servi au calcul des metrics

Lorsque cela est possible, la migration alembic traite aussi les metrics déjà présents dans la table afin de remplir la colonne zone_id et zone_category qui seraient null et sans ambiguité de la zone source sur "zone_name" et "zone_sub_category"