### PR TITLE
feat: API add endpoint vessels/id/times-in-zones from metrics data

### DIFF
--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -59,7 +59,15 @@ class ResponseMetricsVesselTotalTimeActivityByActivityTypeSchema(BaseModel):
     activity: str
     total_activity_time: timedelta
 
-
-
 class TotalTimeActivityTypeRequest(BaseModel):
     type: TotalTimeActivityTypeEnum
+
+
+class VesselTimeInZone(BaseModel):
+    vessel_id: Optional[int] = None
+    zone_id: Optional[int] = None
+    zone_name: Optional[str] = None
+    zone_category: Optional[str] = None
+    zone_sub_category: Optional[str] = None
+    duration_total: Optional[timedelta] = None
+    duration_fishing: Optional[timedelta] = None

--- a/backend/bloom/infra/database/sql_model.py
+++ b/backend/bloom/infra/database/sql_model.py
@@ -277,3 +277,4 @@ class Metrics(Base):
     zone_category= Column("zone_category", String, ForeignKey("dim_zone.category"))
     zone_sub_category= Column("zone_sub_category", String, ForeignKey("dim_zone.sub_category"))
 
+

--- a/backend/bloom/routers/v1/vessels.py
+++ b/backend/bloom/routers/v1/vessels.py
@@ -190,3 +190,29 @@ async def get_vessel_excursion_segment(request: Request, # used by @cache
         result = segment_repository.get_vessel_excursion_segment_by_id(session,vessel_id,excursions_id,segment_id)
         json_data = json.loads(result.model_dump_json() if result else "{}")
     return json_data
+
+@router.get("/vessels/{vessel_id}/times-in-zones")
+@cache
+async def get_vessel_excursion_segment(request: Request, # used by @cache
+                                       vessel_id: int,
+                                        order: OrderByRequest = Depends(),
+                                        datetime_range: DatetimeRangeRequest = Depends(),
+                                        category: Optional[str] = None,
+                                        sub_category: Optional[str] = None,
+                                       nocache:bool=False, # used by @cache
+                                       key: str = Depends(X_API_KEY_HEADER)):
+    check_apikey(key)
+    use_cases = UseCases()
+    vessel_repository = use_cases.vessel_repository()
+    db = use_cases.db()
+    json_data={}
+    with db.session() as session:
+        result = vessel_repository.get_vessel_times_in_zones(session,
+                                                            vessel_id=vessel_id,
+                                                            datetime_range=datetime_range,
+                                                            order=order,
+                                                            category=category,
+                                                            sub_cateogry=sub_category)
+        result=[json.loads(domain.model_dump_json()) for domain in result]
+        #json_data = json.loads(result.model_dump_json() if result else "{}")
+    return result


### PR DESCRIPTION
Feat #339 (qui a disparu)

Rajout du endpoint vessels/{vessel_id}/times-in-zones
       Renvoie le temps passés par zones pour un bateau sur une période donnée
        Paramètres:
        - vessel_id
        - start_at/end_at
        - category
        - sub_category
        - order (by duration_total)
        Valeurs renvoyées:
        - zone_name: nome de la zone
        - zone_category: categorie de la zone
        - zone_sub_category: sous-categorie de la zone
        - duration_total: durée total dans la zone
        - duration_fishing: durée à pêcher