### PR TITLE
feat #204: global endpoints for dashboard rankings

### DIFF
--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -39,6 +39,11 @@ class ResponseMetricsVesselInActivitySchema(BaseModel):
     vessel: VesselListView
     total_time_at_sea: Optional[timedelta]
 
+class ResponseMetricsVesselInMpasSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+    vessel: VesselListView
+    total_time_in_mpas: Optional[timedelta]
+
 class ResponseMetricsZoneVisitedSchema(BaseModel):
     zone: ZoneListView
     visiting_duration: timedelta

--- a/backend/bloom/domain/metrics.py
+++ b/backend/bloom/domain/metrics.py
@@ -39,10 +39,10 @@ class ResponseMetricsVesselInActivitySchema(BaseModel):
     vessel: VesselListView
     total_time_at_sea: Optional[timedelta]
 
-class ResponseMetricsVesselInMpasSchema(BaseModel):
+class ResponseMetricsVesselInZonesSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
     vessel: VesselListView
-    total_time_in_mpas: Optional[timedelta]
+    total_time_in_zones: Optional[timedelta]
 
 class ResponseMetricsZoneVisitedSchema(BaseModel):
     zone: ZoneListView

--- a/backend/bloom/routers/v1/metrics.py
+++ b/backend/bloom/routers/v1/metrics.py
@@ -125,11 +125,12 @@ async def read_metrics_all_vessels_visiting_time_by_zone(request: Request,
     return jsonable_encoder(payload)
 
 
-@router.get("/metrics/vessels/activity-in-mpas")
+@router.get("/metrics/vessels-activity/{category}")
 # @cache
-async def read_metrics_all_vessels_visiting_time_in_mpas(
+async def read_metrics_all_vessels_visiting_time_in_zones(
     request: Request,
     datetime_range: DatetimeRangeRequest = Depends(),
+    category: Optional[str] = None,
     pagination: PageParams = Depends(),
     order: OrderByRequest = Depends(),
     key: str = Depends(X_API_KEY_HEADER),
@@ -137,9 +138,29 @@ async def read_metrics_all_vessels_visiting_time_in_mpas(
     check_apikey(key)
     use_cases = UseCases()
     MetricsService = use_cases.metrics_service()
-    payload = MetricsService.get_vessels_in_mpas(
+    payload = MetricsService.get_vessels_activity_in_zones(
         datetime_range=datetime_range,
         pagination=pagination,
-        order=order
+        order=order,
+        category=category,
+    )
+    return jsonable_encoder(payload)
+
+
+@router.get("/metrics/zones-visited/{category}")
+# @cache
+async def read_metrics_all_zones_visited(
+    request: Request,
+    datetime_range: DatetimeRangeRequest = Depends(),
+    category: Optional[str] = None,
+    pagination: PageParams = Depends(),
+    order: OrderByRequest = Depends(),
+    key: str = Depends(X_API_KEY_HEADER),
+):
+    check_apikey(key)
+    use_cases = UseCases()
+    MetricsService = use_cases.metrics_service()
+    payload = MetricsService.get_zones_visited(
+        datetime_range=datetime_range, pagination=pagination, order=order, category=category
     )
     return jsonable_encoder(payload)

--- a/backend/bloom/routers/v1/metrics.py
+++ b/backend/bloom/routers/v1/metrics.py
@@ -123,3 +123,23 @@ async def read_metrics_all_vessels_visiting_time_by_zone(request: Request,
                                                 category=category,
                                                 sub_category=sub_category)
     return jsonable_encoder(payload)
+
+
+@router.get("/metrics/vessels/activity-in-mpas")
+# @cache
+async def read_metrics_all_vessels_visiting_time_in_mpas(
+    request: Request,
+    datetime_range: DatetimeRangeRequest = Depends(),
+    pagination: PageParams = Depends(),
+    order: OrderByRequest = Depends(),
+    key: str = Depends(X_API_KEY_HEADER),
+):
+    check_apikey(key)
+    use_cases = UseCases()
+    MetricsService = use_cases.metrics_service()
+    payload = MetricsService.get_vessels_in_mpas(
+        datetime_range=datetime_range,
+        pagination=pagination,
+        order=order
+    )
+    return jsonable_encoder(payload)

--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -1,11 +1,17 @@
-"use client"
+"use client";
 
-import { useMemo, useState } from "react"
-import { useDashboardData } from "@/services/dashboard.service"
+import { useMemo, useState } from "react";
+import { useDashboardData } from "@/services/dashboard.service";
 
-import { getDateRange } from "@/libs/dateUtils"
-import DashboardHeader from "@/components/dashboard/dashboard-header"
-import DashboardOverview from "@/components/dashboard/dashboard-overview"
+
+
+import { getDateRange } from "@/libs/dateUtils";
+import DashboardHeader from "@/components/dashboard/dashboard-header";
+import DashboardOverview from "@/components/dashboard/dashboard-overview";
+
+
+
+
 
 export default function DashboardPage() {
   const [selectedDays, setSelectedDays] = useState(7)
@@ -14,7 +20,7 @@ export default function DashboardPage() {
   }, [selectedDays])
 
   const {
-    topVesselsInActivity,
+    topVesselsInMpas,
     topAmpsVisited,
     totalVesselsInActivity,
     totalAmpsVisited,
@@ -31,7 +37,7 @@ export default function DashboardPage() {
 
         <div className="size-full">
           <DashboardOverview
-            topVesselsInActivity={topVesselsInActivity}
+            topVesselsInMpas={topVesselsInMpas}
             topAmpsVisited={topAmpsVisited}
             totalVesselsActive={totalVesselsInActivity}
             totalAmpsVisited={totalAmpsVisited}
@@ -39,7 +45,7 @@ export default function DashboardPage() {
             onDateRangeChange={(value) => {
               setSelectedDays(Number(value))
             }}
-            topVesselsInActivityLoading={isLoading.topVesselsInActivity}
+            topVesselsInMpasLoading={isLoading.topVesselsInMpas}
             topAmpsVisitedLoading={isLoading.topAmpsVisited}
             totalVesselsActiveLoading={isLoading.totalVesselsInActivity}
             totalAmpsVisitedLoading={isLoading.totalAmpsVisited}

--- a/frontend/components/dashboard/dashboard-overview.tsx
+++ b/frontend/components/dashboard/dashboard-overview.tsx
@@ -1,16 +1,21 @@
-"use client"
+"use client";
 
-import { TOTAL_AMPS, TOTAL_VESSELS } from "@/constants/totals.constants"
+import { TOTAL_AMPS, TOTAL_VESSELS } from "@/constants/totals.constants";
 
-import { Item } from "@/types/item"
-import ListCard from "@/components/ui/list-card"
-import KPICard from "@/components/dashboard/kpi-card"
 
-import { DateRangeSelector } from "../ui/date-range-selector"
+
+import { Item } from "@/types/item";
+import ListCard from "@/components/ui/list-card";
+import KPICard from "@/components/dashboard/kpi-card";
+
+
+
+import { DateRangeSelector } from "../ui/date-range-selector";
+
 
 type Props = {
-  topVesselsInActivity: Item[]
-  topVesselsInActivityLoading: boolean
+  topVesselsInMpas: Item[]
+  topVesselsInMpasLoading: boolean
   topAmpsVisited: Item[]
   topAmpsVisitedLoading: boolean
   totalVesselsActive: number
@@ -23,8 +28,8 @@ type Props = {
 }
 
 export default function DashboardOverview({
-  topVesselsInActivity,
-  topVesselsInActivityLoading,
+  topVesselsInMpas,
+  topVesselsInMpasLoading,
   topAmpsVisited,
   topAmpsVisitedLoading,
   totalVesselsActive,
@@ -74,9 +79,9 @@ export default function DashboardOverview({
             <ListCard
               key="top-vessels-in-activity"
               title="Top Vessels visiting MPAs"
-              items={topVesselsInActivity ?? []}
+              items={topVesselsInMpas ?? []}
               enableViewDetails
-              loading={topVesselsInActivityLoading}
+              loading={topVesselsInMpasLoading}
               titleClassName="absolute -top-8 xl:-top-10"
             />
           </div>

--- a/frontend/libs/mapper.tsx
+++ b/frontend/libs/mapper.tsx
@@ -11,7 +11,7 @@ export function convertVesselDtoToItem(metrics: VesselMetrics[]): Item[] {
         id: `${vessel.id}`,
         title: vessel.ship_name,
         description: `IMO ${vessel.imo} / MMSI ${vessel.mmsi} / ${vessel.length} m`,
-        value: convertDurationToString(vesselMetrics.total_time_at_sea),
+        value: convertDurationToString(vesselMetrics.total_time_in_mpas),
         type: "vessel",
         countryIso3: vessel.country_iso3,
       }

--- a/frontend/services/backend-rest-client.ts
+++ b/frontend/services/backend-rest-client.ts
@@ -83,12 +83,12 @@ export async function getVesselFirstExcursionSegments(vesselId: number) {
   }
 }
 
-export function getTopVesselsInActivity(
+export function getTopVesselsInMpas(
   startAt: string,
   endAt: string,
   topVesselsLimit: number
 ) {
-  const url = `${BASE_URL}/metrics/vessels-in-activity?start_at=${startAt}&end_at=${endAt}&limit=${topVesselsLimit}&order=DESC`
+  const url = `${BASE_URL}/metrics/vessels/activity-in-mpas?start_at=${startAt}&end_at=${endAt}&limit=${topVesselsLimit}&order=DESC`
   console.log(`GET ${url}`)
   return axios.get<VesselMetrics[]>(url)
 }

--- a/frontend/services/dashboard.service.ts
+++ b/frontend/services/dashboard.service.ts
@@ -1,6 +1,6 @@
 import { TOTAL_VESSELS } from "@/constants/totals.constants"
 import {
-  getTopVesselsInActivity,
+  getTopVesselsInMpas,
   getTopZonesVisited,
   getVesselsAtSea,
   getVesselsTrackedCount,
@@ -13,13 +13,13 @@ import { convertVesselDtoToItem, convertZoneDtoToItem } from "@/libs/mapper"
 const TOP_ITEMS_SIZE = 5
 
 type DashboardData = {
-  topVesselsInActivity: any[]
+  topVesselsInMpas: any[]
   topAmpsVisited: any[]
   totalVesselsInActivity: number
   totalAmpsVisited: number
   totalVesselsTracked: number
   isLoading: {
-    topVesselsInActivity: boolean
+    topVesselsInMpas: boolean
     topAmpsVisited: boolean
     totalVesselsInActivity: boolean
     totalAmpsVisited: boolean
@@ -32,13 +32,13 @@ export const useDashboardData = (
   endAt: string
 ): DashboardData => {
   const {
-    data: topVesselsInActivity = [],
-    isLoading: topVesselsInActivityLoading,
+    data: topVesselsInMpas = [],
+    isLoading: topVesselsInMpasLoading,
   } = useSWR(
-    `topVesselsInActivity-${startAt}`,
+    `topVesselsInMpas-${startAt}`,
     async () => {
       try {
-        const response = await getTopVesselsInActivity(
+        const response = await getTopVesselsInMpas(
           startAt,
           endAt,
           TOP_ITEMS_SIZE
@@ -46,7 +46,7 @@ export const useDashboardData = (
         return convertVesselDtoToItem(response?.data || [])
       } catch (error) {
         console.log(
-          "An error occurred while fetching top vessels in activity: " + error
+          "An error occurred while fetching top vessels in MPAs: " + error
         )
         return []
       }
@@ -137,13 +137,13 @@ export const useDashboardData = (
   )
 
   return {
-    topVesselsInActivity,
+    topVesselsInMpas,
     topAmpsVisited,
     totalVesselsInActivity,
     totalAmpsVisited,
     totalVesselsTracked,
     isLoading: {
-      topVesselsInActivity: topVesselsInActivityLoading,
+      topVesselsInMpas: topVesselsInMpasLoading,
       topAmpsVisited: topAmpsVisitedLoading,
       totalVesselsInActivity: totalVesselsInActivityLoading,
       totalAmpsVisited: totalAmpsVisitedLoading,

--- a/frontend/types/vessel.ts
+++ b/frontend/types/vessel.ts
@@ -17,7 +17,7 @@ export type Vessel = {
 
 export type VesselMetrics = {
   vessel: VesselDetails
-  total_time_at_sea: string
+  total_time_in_mpas: string
 }
 
 export type VesselDetails = {


### PR DESCRIPTION
J'ai enfin compris le ticket #204 et #309 : ils étaient redondants. J'ai donc créé les 2 endpoints globaux pour remplacer ceux pour les classements sur le dashboard :
/metrics/vessels-activity/{category} => liste des navires avec la durée de visite dans les zones de catégorie `category` dans une plage de temps donnée
/metrics/zones-visited/category} => liste des zones visitées de catégorie `category`  avec la durée de visite dans une plage de temps donnée