### PR TITLE
425/426 reprendre tâche clean_positions

### DIFF
--- a/backend/alembic/versions/dcf999bd43af_create_position_updates.py
+++ b/backend/alembic/versions/dcf999bd43af_create_position_updates.py
@@ -1,0 +1,39 @@
+"""create_position_updates
+
+Revision ID: dcf999bd43af
+Revises: 5801cb8f1af5
+Create Date: 2025-02-25 14:58:48.958984
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.sql import func
+
+
+# revision identifiers, used by Alembic.
+revision = 'dcf999bd43af'
+down_revision = '5801cb8f1af5'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "position_updates",
+        sa.Column("id", sa.Integer(), sa.Identity(), primary_key=True, index=True),
+        sa.Column(
+            "vessel_id", sa.Integer, sa.ForeignKey("dim_vessel.id"), nullable=False
+        ),
+        sa.Column("point_in_time", sa.DateTime(timezone=True)),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=func.now(),
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), onupdate=func.now()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("position_updates")

--- a/backend/bloom/container.py
+++ b/backend/bloom/container.py
@@ -1,3 +1,4 @@
+from bloom.infra.repositories.repository_position_updates import PositionUpdateRepository
 from bloom.config import settings
 from bloom.infra.database.database_manager import Database
 from bloom.infra.repositories.repository_alert import RepositoryAlert
@@ -94,5 +95,10 @@ class UseCases(containers.DeclarativeContainer):
 
     metrics_repository = providers.Factory(
         MetricsRepository,
+        session_factory=db.provided.session,
+    )
+
+    position_update_repository = providers.Factory(
+        PositionUpdateRepository,
         session_factory=db.provided.session,
     )

--- a/backend/bloom/domain/position_update.py
+++ b/backend/bloom/domain/position_update.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Union
+
+from bloom.infra.database import sql_model
+from pydantic import BaseModel, ConfigDict
+
+
+class PositionUpdate(BaseModel):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+    )
+    id: Union[int, None] = None
+    vessel_id: int
+    point_in_time: datetime | None
+    created_at: Union[datetime, None] = None
+    updated_at: Union[datetime, None] = None
+
+    @staticmethod
+    def from_model(entity: sql_model.PositionUpdate):
+        return PositionUpdate(
+            id=entity.id,
+            vessel_id=entity.vessel_id,
+            point_in_time=entity.point_in_time,
+            created_at=entity.created_at,
+            updated_at=entity.updated_at,
+        )

--- a/backend/bloom/infra/database/sql_model.py
+++ b/backend/bloom/infra/database/sql_model.py
@@ -261,7 +261,7 @@ class MetricsVesselInActivity(Base):
     __table__ = vessel_in_activity_request
     #vessel_id: Mapped[Optional[int]]
     #total_time_at_sea: Mapped[Optional[timedelta]]
-    
+
 
 class Metrics(Base):
     __tablename__ = "fct_metrics"
@@ -281,3 +281,14 @@ class Metrics(Base):
     zone_enable = Column("enable",Boolean(), server_default="True")
 
 
+class PositionUpdate(Base):
+    __tablename__= "position_updates"
+    id = Column("id", Integer, Identity(), primary_key=True)
+    vessel_id = Column(
+        "vessel_id", Integer, ForeignKey("dim_vessel.id")
+    )
+    point_in_time = Column("point_in_time", DateTime(timezone=True))
+    created_at = Column(
+        "created_at", DateTime(timezone=True), server_default=func.now()
+    )
+    updated_at = Column("updated_at", DateTime(timezone=True), onupdate=func.now())

--- a/backend/bloom/infra/repositories/repository_position_updates.py
+++ b/backend/bloom/infra/repositories/repository_position_updates.py
@@ -1,0 +1,57 @@
+from dependency_injector.providers import Callable
+from bloom.domain.position_update import PositionUpdate
+from bloom.infra.database import sql_model
+from sqlalchemy.orm import Session
+from sqlalchemy import select
+
+
+class PositionUpdateRepository:
+
+    def __init__(self, session_factory: Callable) -> None:
+        self.session_factory = session_factory
+
+    @staticmethod
+    def find_record_by_vessel_id(
+        session: Session, vessel_id: int
+    ) -> PositionUpdate | None:
+        """Recheche l'excursion en cours d'un bateau, c'est-à-dire l'excursion qui n'a pas de date d'arrivée"""
+        stmt = select(sql_model.PositionUpdate).where(
+            (sql_model.PositionUpdate.vessel_id == vessel_id)
+        )
+        result = session.execute(stmt).scalar_one_or_none()
+        if not result:
+            return None
+        return PositionUpdateRepository.map_to_domain(result)
+
+    def batch_update_position_timestamp_update(
+        self, session: Session, position_updates: list[PositionUpdate]
+    ) -> list[PositionUpdate]:
+        updated_position_timestamp_updates = []
+        for entity in position_updates:
+            orm = PositionUpdateRepository.map_to_sql(entity)
+            session.merge(orm)
+            session.flush()
+            updated_position_timestamp_updates.append(
+                PositionUpdateRepository.map_to_domain(orm)
+            )
+        return updated_position_timestamp_updates
+
+    @staticmethod
+    def map_to_sql(position_update: PositionUpdate) -> sql_model.PositionUpdate:
+        return sql_model.PositionUpdate(
+            id=position_update.id,
+            vessel_id=position_update.vessel_id,
+            point_in_time=position_update.point_in_time,
+            created_at=position_update.created_at,
+            updated_at=position_update.updated_at,
+        )
+
+    @staticmethod
+    def map_to_domain(position_update: sql_model.PositionUpdate) -> PositionUpdate:
+        return PositionUpdate(
+            id=position_update.id,
+            vessel_id=position_update.vessel_id,
+            point_in_time=position_update.point_in_time,
+            created_at=position_update.created_at,
+            updated_at=position_update.updated_at,
+        )

--- a/backend/bloom/infra/repositories/repository_vessel_position.py
+++ b/backend/bloom/infra/repositories/repository_vessel_position.py
@@ -27,6 +27,7 @@ class VesselPositionRepository:
         VesselPosition]:
         orm_list = [VesselPositionRepository.map_to_sql(vessel_position) for vessel_position in vessel_positions]
         session.add_all(orm_list)
+        session.flush()
         return [VesselPositionRepository.map_to_domain(orm) for orm in orm_list]
 
     def get_all_vessel_last_positions(self, session: Session) -> List[VesselPosition]:

--- a/backend/bloom/tasks/clean_positions.py
+++ b/backend/bloom/tasks/clean_positions.py
@@ -1,28 +1,15 @@
-import argparse
 import warnings
-from datetime import datetime,timedelta, timezone
-from time import perf_counter
 
-import numpy as np
 import pandas as pd
-from geopy import distance
+from bloom.domain.position_update import PositionUpdate
 from shapely.geometry import Point
 
 from bloom.container import UseCases
 from bloom.domain.vessel_position import VesselPosition
-from bloom.infra.repositories.repository_task_execution import TaskExecutionRepository
 from bloom.logger import logger
+from time import perf_counter
 
 warnings.filterwarnings("ignore")
-
-
-# distance.distance takes pair of (lat, lon) tuples:
-def get_distance(current_position: tuple, last_position: tuple):
-    if np.isnan(last_position[0]) or np.isnan(last_position[1]):
-        return np.nan
-
-    return distance.geodesic(current_position, last_position).km
-
 
 def map_vessel_position_to_domain(row: pd.Series) -> VesselPosition:
     return VesselPosition(
@@ -38,163 +25,109 @@ def map_vessel_position_to_domain(row: pd.Series) -> VesselPosition:
         maneuver=row["position_maneuver"],
         navigational_status=row["position_navigational_status"],
         rot=row["position_rot"],
-        speed=row["speed"],
+        speed=row["position_speed"],
     )
 
 
-def to_coords(row: pd.Series) -> pd.Series:
-    if pd.isna(row["end_position"]) is False:
-        row["longitude"] = row["end_position"].x
-        row["latitude"] = row["end_position"].y
+def map_position_update_to_domain(row: pd.Series) -> PositionUpdate:
+    return PositionUpdate(
+        vessel_id=row["vessel_id"], 
+        point_in_time=row["position_update_timestamp"]
+    )
 
-    return row
 
-
-def run(batch_time):
+def run():
     use_cases = UseCases()
     db = use_cases.db()
     spire_repository = use_cases.spire_ais_data_repository()
-    excursion_repository = use_cases.excursion_repository()
-    segment_repository = use_cases.segment_repository()
     vessel_position_repository = use_cases.vessel_position_repository()
-    process_start=datetime.now(timezone.utc)
-    point_in_time=None
+    position_update_repository = use_cases.position_update_repository()
     position_count=None
-    with db.session() as session:
-        point_in_time = TaskExecutionRepository.get_point_in_time(
-            session, "clean_positions",
-        )
-        batch_limit = point_in_time + timedelta(days=batch_time)
-        # Step 1: load SPIRE batch: read from SpireAisData
-        logger.info(f"Lecture des nouvelles positions de Spire en base")
-        batch = spire_repository.get_all_data_between_date(session, point_in_time, batch_limit)
 
-        # Recherche de la date de l'enregistrement traité le plus récent.
-        # Cette date est stockée comme date d'exécution du traitement ce qui permettra de repartir de cette date
-        # à la prochaine execution pour traiter les enregistrements + récents
-        max_created = max(batch["created_at"]) if len(batch) > 0 else batch_limit
-        logger.info(f"Traitement des positions entre le {point_in_time} et le {max_created}")
-        position_count=len(batch)
-        logger.info(f"{position_count} nouvelles positions de Spire")
-        batch.dropna(
-            subset=[
+    def __init_entity_from_dataframe__(session, entity_info: pd.Series) -> PositionUpdate:
+        entity = position_update_repository.find_record_by_vessel_id(
+            session, entity_info['vessel_id']
+        )
+
+        if not entity:
+            entity = PositionUpdate(vessel_id=entity_info["vessel_id"])
+        entity.point_in_time = entity_info["max_timestamp"]
+
+        return entity
+
+    with db.session() as session:
+
+        # Récupération des données Spire en se basant sur le dernier timestamp de mise à jour de position utilisé
+        data = spire_repository.get_all_data_after_position_updates_per_vessel_id(session)
+        logger.info(f"{len(data)} spire data with new updated position timestamp")
+
+        # Sélection des variables
+        positions: pd.DataFrame = data[
+            [
+                "vessel_id",
+                "spire_update_statement",
+                "position_accuracy",
+                "position_collection_type",
+                "vessel_mmsi",
+                "position_course",
+                "position_heading",
                 "position_latitude",
                 "position_longitude",
+                "position_maneuver",
+                "position_navigational_status",
+                "position_rot",
+                "position_speed",
                 "position_timestamp",
                 "position_update_timestamp",
-            ],
-            inplace=True,
+            ]
+        ]
+
+        # Filtrage des duplicats
+        positions.drop_duplicates(inplace=True)
+        logger.info(f"{len(positions)} positions to map")
+
+        # Save new positions
+        mapped_positions = positions.apply(
+            map_vessel_position_to_domain, axis=1
+        ).values.tolist()
+
+        vessel_position_repository.batch_create_vessel_position(
+            session, mapped_positions
+        )
+        session.flush()
+
+        logger.info(f"{len(mapped_positions)} mapped positions")
+
+        # Mettre à jour position_updates
+        df = positions[
+            ["vessel_id", "position_update_timestamp"]
+        ].drop_duplicates()
+
+        df["max_timestamp"] = df.groupby(["vessel_id"])[
+            "position_update_timestamp"
+        ].transform(max)
+
+        position_update_timestamps = df[
+            ["vessel_id", "max_timestamp"]
+        ].drop_duplicates()
+
+        entities = []
+
+        for id, entity_info in position_update_timestamps.iterrows():
+            entity = __init_entity_from_dataframe__(session, entity_info)
+            entities.append(entity)
+
+        position_update_repository.batch_update_position_timestamp_update(
+            session, entities
         )
 
-        # Step 2: load excursion from fct_excursion where date_arrival IS NULL
-        excursions = excursion_repository.get_current_excursions(session)
-
-        # Step 3: load last_segment where last_vessel_segment == 1
-        last_segment = segment_repository.get_last_vessel_id_segments(session)
-        last_segment["longitude"] = None
-        last_segment["latitude"] = None
-        last_segment = last_segment.apply(to_coords, axis=1)
-
-        # Step 4: merge batch with last_segment on vessel_id.
-        # If column _merge == "left_only" --> this is a new vessel (keep it)
-        batch = batch.merge(
-            last_segment,
-            how="left",
-            on="vessel_id",
-            suffixes=["", "_segment"],
-            indicator=True,
-        )
-        batch.rename(columns={"_merge": "new_vessel"}, inplace=True)
-        batch["new_vessel"] = batch["new_vessel"] == "left_only"
-
-        # Step 5: merge batch with excursions
-        # If column _merge == "left_only" --> the excursion is closed
-        batch = batch.merge(
-            excursions,
-            how="left",
-            on="vessel_id",
-            suffixes=["", "_excursion"],
-            indicator=True,
-        )
-        batch.rename(columns={"_merge": "excursion_closed"}, inplace=True)
-        batch["excursion_closed"] = batch["excursion_closed"] == "left_only"
-
-        # Step 6: compute speed between last and current position
-        # Step 6.1. Compute distance in km between last and current position
-        batch["distance_since_last_position"] = batch.apply(
-            lambda row: get_distance(
-                (row["position_latitude"], row["position_longitude"]),
-                (row["latitude"], row["longitude"]),
-            ),
-            axis=1,
-        )
-
-        # Step 6.2. Compute time in hours between last and current position
-        ## If timestamp_end is NULL --> new_vessel is TRUE (record will be kept)
-        ## --> fillna with anything to avoid exception
-        batch.loc[batch["timestamp_end"].isna(), "timestamp_end"] = batch.loc[
-            batch["timestamp_end"].isna(), "position_timestamp"
-        ].copy()
-        batch["timestamp_end"] = pd.to_datetime(batch["timestamp_end"], utc=True)
-        batch["position_timestamp"] = pd.to_datetime(batch["position_timestamp"], utc=True)
-        batch["time_since_last_position"] = (
-                batch["position_timestamp"] - batch["timestamp_end"]
-        )
-        batch["hours_since_last_position"] = (
-                batch["time_since_last_position"].dt.seconds / 3600
-        )
-
-        # Step 6.3. Compute speed: speed = distance / time
-        batch["speed"] = (
-                batch["distance_since_last_position"] / batch["hours_since_last_position"]
-        )
-        batch["speed"] *= 0.5399568  # Conversion km/h to
-        batch["speed"] = batch["speed"].fillna(batch["position_speed"])
-        batch.replace([np.nan], [None], inplace=True)
-        # Step 7: apply to_keep flag: keep only positions WHERE:
-        # - row["new_vessel"] is True, i.e. there is a new vessel_id
-        # - OR speed is not close to 0, i.e. vessel moved significantly since last position
-        batch["to_keep"] = (batch["new_vessel"] == True) | ~(  # detect new vessels
-                (batch["excursion_closed"] == True)  # if last excursion closed
-                & (batch["speed"] <= 0.01)  # and speed < 0.01: don't keep
-        )
-
-        # Step 8: filter unflagged rows to insert to DB
-        batch = batch.loc[batch["to_keep"] == True].copy()
-
-        # Step 9: insert to DataBase
-        clean_positions = batch.apply(map_vessel_position_to_domain, axis=1).values.tolist()
-        vessel_position_repository.batch_create_vessel_position(session, clean_positions)
-        TaskExecutionRepository.set_point_in_time(session, "clean_positions", max_created)
-        logger.info(f"Ecriture de {len(clean_positions)} positions dans la table vessel_positions")
-        session.commit()
-        if point_in_time:
-            TaskExecutionRepository.set_duration(session,
-                                             "clean_positions",
-                                             max_created,
-                                             datetime.now(timezone.utc)-process_start)
-        if position_count != None:
-            TaskExecutionRepository.set_position_count(session,
-                                             "clean_positions",
-                                             max_created,
-                                             position_count)
-        session.commit()
+        # session.commit()
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Clean position")
-    parser.add_argument(
-        "-b",
-        "--batch-time",
-        type=int,
-        help="batch size in days",
-        required=False,
-        default=7,
-    )
-    args = parser.parse_args()
     time_start = perf_counter()
     logger.info("DEBUT - Nettoyage des positions")
-    run(args.batch_time)
+    run()
     time_end = perf_counter()
     duration = time_end - time_start
     logger.info(f"FIN - Nettoyage des positions en {duration:.2f}s")


### PR DESCRIPTION
J'ai utilisé `position_update_timestamp` dans `spire_ais_data` mais je ne vois pas de contre indication à utiliser `spire_update_statement` #402 

Je ne me suis pas fiée au modèle d'archi qu'on aimerait pour la refacto. Je ne sais pas encore quel modèle a finalement été choisi.